### PR TITLE
Fix code style across the package

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -6,7 +6,6 @@ linters: linters_with_tags(
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
-    indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())

--- a/R/borel.r
+++ b/R/borel.r
@@ -24,10 +24,11 @@ dborel <- function(x, mu, log = FALSE) {
 ##' @author Sebastian Funk
 ##' @export
 rborel <- function(n, mu, infinite = Inf) {
-  simulate_summary(nchains = n,
-                offspring_dist = "pois",
-                statistic = "size",
-                stat_max = infinite,
-                lambda = mu
-                )
+  simulate_summary(
+    nchains = n,
+    offspring_dist = "pois",
+    statistic = "size",
+    stat_max = infinite,
+    lambda = mu
+  )
 }

--- a/R/checks.R
+++ b/R/checks.R
@@ -24,7 +24,7 @@ check_offspring_valid <- function(offspring_dist) {
 #' @keywords internal
 check_offspring_func_valid <- function(roffspring_name) {
   if (!(exists(roffspring_name)) ||
-      !checkmate::test_function(get(roffspring_name))) {
+        !checkmate::test_function(get(roffspring_name))) {
     stop("Function ", roffspring_name, " does not exist.")
   }
 }

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -45,22 +45,23 @@ format.epichains <- function(x, ...) {
     )
 
     # Offer more information to view the full dataset
-    writeLines(sprintf("%s %s", "Use `as.data.frame(<object_name>)`",
-                       "to view the full output in the console.")
-               )
-
+    writeLines(sprintf(
+      "%s %s", "Use `as.data.frame(<object_name>)`",
+      "to view the full output in the console."
+    ))
   } else if (is_chains_summary(x)) {
     writeLines(sprintf("`epichains` object \n"))
     print(as.vector(x))
-    writeLines(sprintf("\n Number of chains simulated: %s",
-                chain_info[["unique_chains"]]
-                )
-        )
+    writeLines(sprintf(
+      "\n Number of chains simulated: %s",
+      chain_info[["unique_chains"]]
+    ))
     writeLines(
       c(
-        sprintf("\n Simulated chain %ss: \n",
-                attr(x, "statistic", exact = TRUE)
-                ),
+        sprintf(
+          "\n Simulated chain %ss: \n",
+          attr(x, "statistic", exact = TRUE)
+        ),
         sprintf("Max: %s", chain_info[["max_chain_stat"]]),
         sprintf("Min: %s", chain_info[["min_chain_stat"]])
       )
@@ -86,7 +87,6 @@ summary.epichains <- function(object, ...) {
   chains_ran <- attr(object, "chains", exact = TRUE)
 
   if (is_chains_tree(object)) {
-
     max_time <- max(object$time)
 
     n_unique_ancestors <- length(
@@ -97,17 +97,17 @@ summary.epichains <- function(object, ...) {
 
     # out of summary
     res <- list(
-      chains_ran =  chains_ran,
+      chains_ran = chains_ran,
       max_time = max_time,
       unique_ancestors = n_unique_ancestors,
       max_generation = max_generation
     )
   } else if (is_chains_summary(object)) {
     if (!all(is.infinite(object))) {
-    max_chain_stat <- max(object[!is.infinite(object)])
-    min_chain_stat <- min(object[!is.infinite(object)])
+      max_chain_stat <- max(object[!is.infinite(object)])
+      min_chain_stat <- min(object[!is.infinite(object)])
     } else {
-    max_chain_stat <- min_chain_stat <- Inf
+      max_chain_stat <- min_chain_stat <- Inf
     }
 
     res <- list(
@@ -115,7 +115,7 @@ summary.epichains <- function(object, ...) {
       max_chain_stat = max_chain_stat,
       min_chain_stat = min_chain_stat
     )
-    }
+  }
 
   return(res)
 }
@@ -161,7 +161,7 @@ validate_epichains <- function(x) {
     stopifnot(
       "object does not contain the correct columns" =
         c("sim_id", "ancestor", "generation") %in%
-          colnames(x),
+        colnames(x),
       "column `sim_id` must be a numeric" =
         is.numeric(x$sim_id),
       "column `ancestor` must be a numeric" =
@@ -255,9 +255,11 @@ tail.epichains <- function(x, ...) {
 #' @author James M. Azam
 #' @examples
 #' set.seed(123)
-#' chains <- simulate_tree(nchains = 10, statistic = "size",
-#' offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
-#' lambda = 2)
+#' chains <- simulate_tree(
+#'   nchains = 10, statistic = "size",
+#'   offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
+#'   lambda = 2
+#' )
 #' chains
 #'
 #' # Aggregate cases per time
@@ -269,10 +271,11 @@ tail.epichains <- function(x, ...) {
 #' # Aggregate cases per both time and generation
 #' aggregate(chains, grouping_var = "both")
 aggregate.epichains <- function(x,
-                                grouping_var = c("time",
-                                                 "generation",
-                                                 "both"
-                                                 ),
+                                grouping_var = c(
+                                  "time",
+                                  "generation",
+                                  "both"
+                                ),
                                 ...) {
   validate_epichains(x)
   # Check that the object is of type "chains_tree"
@@ -288,30 +291,37 @@ aggregate.epichains <- function(x,
 
   out <- if (grouping_var == "time") {
     # Count the number of cases per generation
-    stats::aggregate(list(cases = x$sim_id),
+    stats::aggregate(
+      list(cases = x$sim_id),
       list(time = x$time),
       FUN = NROW
     )
   } else if (grouping_var == "generation") {
     # Count the number of cases per time
-    stats::aggregate(list(cases = x$sim_id),
+    stats::aggregate(
+      list(cases = x$sim_id),
       list(generation = x$generation),
       FUN = NROW
     )
   } else if (grouping_var == "both") {
     # Count the number of cases per time
     list(
-      stats::aggregate(list(cases = x$sim_id),
-                       list(time = x$time),
-                       FUN = NROW),
+      stats::aggregate(
+        list(cases = x$sim_id),
+        list(time = x$time),
+        FUN = NROW
+      ),
       # Count the number of cases per generation
-      stats::aggregate(list(cases = x$sim_id),
-                       list(generation = x$generation),
-                       FUN = NROW)
+      stats::aggregate(
+        list(cases = x$sim_id),
+        list(generation = x$generation),
+        FUN = NROW
+      )
     )
   }
 
-  structure(out,
+  structure(
+    out,
     class = c("epichains_aggregate_df", class(out)),
     chain_type = attributes(x)$chain_type,
     rownames = NULL,

--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -25,8 +25,10 @@
 #' @examples
 #' # example of observed chain sizes
 #' chain_sizes <- c(1, 1, 4, 7)
-#' likelihood(chains = chain_sizes, statistic = "size",
-#'  offspring_dist = "pois", nsim_obs = 100, lambda = 0.5)
+#' likelihood(
+#'   chains = chain_sizes, statistic = "size",
+#'   offspring_dist = "pois", nsim_obs = 100, lambda = 0.5
+#' )
 #' @export
 likelihood <- function(chains, statistic = c("size", "length"), offspring_dist,
                        nsim_obs, log = TRUE, obs_prob = 1, stat_max = Inf,
@@ -44,14 +46,17 @@ likelihood <- function(chains, statistic = c("size", "length"), offspring_dist,
 
     sample_func <- get_statistic_func(statistic)
 
-    sampled_x <- replicate(nsim_obs, pmin(sample_func(length(chains),
-                                           chains, obs_prob
-                                           ),
-                               stat_max), simplify = FALSE)
+    sampled_x <- replicate(nsim_obs, pmin(
+      sample_func(
+        length(chains),
+        chains, obs_prob
+      ),
+      stat_max
+    ), simplify = FALSE)
     size_x <- unlist(sampled_x)
     if (!is.finite(stat_max)) {
       stat_max <- max(size_x) + 1
-      }
+    }
   } else {
     chains[chains >= stat_max] <- stat_max
     size_x <- chains

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -71,9 +71,11 @@
 #' statistic without the tree of infections.
 #' @examples
 #' set.seed(123)
-#' chains <- simulate_tree(nchains = 10, statistic = "size",
-#' offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
-#' lambda = 2)
+#' chains <- simulate_tree(
+#'   nchains = 10, statistic = "size",
+#'   offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
+#'   lambda = 2
+#' )
 #' @references
 #'
 #' Lehtinen S, Ashcroft P, Bonhoeffer S. On the relationship
@@ -143,9 +145,11 @@ simulate_tree <- function(nchains, statistic = c("size", "length"),
     n_offspring[sim] <- tapply(next_gen, indices, sum)
 
     # track size/length
-    stat_track <- update_chain_stat(stat_type = statistic,
-                                    stat_latest = stat_track,
-                                    n_offspring = n_offspring)
+    stat_track <- update_chain_stat(
+      stat_type = statistic,
+      stat_latest = stat_track,
+      n_offspring = n_offspring
+    )
 
     # record times/ancestors
     if (sum(n_offspring[sim]) > 0) {
@@ -188,17 +192,17 @@ simulate_tree <- function(nchains, statistic = c("size", "length"),
         sim <- intersect(sim, unique(indices)[current_min_time < tf])
       }
       if (!missing(serials_sampler)) {
-          times <- times[indices %in% sim]
-          }
-        ancestor_ids <- ids[indices %in% sim]
+        times <- times[indices %in% sim]
+      }
+      ancestor_ids <- ids[indices %in% sim]
     }
-    }
+  }
 
   if (!missing(tf)) {
     tree_df <- tree_df[tree_df$time < tf, ]
   }
 
-  #sort by sim_id and ancestor
+  # sort by sim_id and ancestor
   tree_df <- tree_df[order(tree_df$sim_id, tree_df$ancestor), ]
 
   structure(
@@ -219,12 +223,14 @@ simulate_tree <- function(nchains, statistic = c("size", "length"),
 #' @param stat_max A cut off for the chain statistic (size/length) being
 #' computed. Results above the specified value, are set to `Inf`.
 #' @examples
-#' simulate_summary(nchains = 10, statistic = "size", offspring_dist = "pois",
-#' stat_max = 10, lambda = 2)
+#' simulate_summary(
+#'   nchains = 10, statistic = "size", offspring_dist = "pois",
+#'   stat_max = 10, lambda = 2
+#' )
 #' @export
 simulate_summary <- function(nchains, statistic = c("size", "length"),
-                          offspring_dist,
-                          stat_max = Inf, ...) {
+                             offspring_dist,
+                             stat_max = Inf, ...) {
   statistic <- match.arg(statistic)
 
   check_nchains_valid(nchains = nchains)
@@ -258,10 +264,11 @@ simulate_summary <- function(nchains, statistic = c("size", "length"),
     n_offspring[sim] <- tapply(next_gen, indices, sum)
 
     # track size/length
-    stat_track <- update_chain_stat(stat_type = statistic,
-                                    stat_latest = stat_track,
-                                    n_offspring = n_offspring
-                                    )
+    stat_track <- update_chain_stat(
+      stat_type = statistic,
+      stat_latest = stat_track,
+      n_offspring = n_offspring
+    )
 
     ## only continue to simulate chains that offspring and aren't of
     ## stat_max size/length
@@ -325,12 +332,16 @@ simulate_summary <- function(nchains, statistic = c("size", "length"),
 #' @author James M. Azam
 #' @examples
 #' # Simulate with poisson offspring
-#' simulate_tree_from_pop(pop = 100, offspring_dist = "pois",
-#' offspring_mean = 0.5, serial_sampler = function(x) 3)
+#' simulate_tree_from_pop(
+#'   pop = 100, offspring_dist = "pois",
+#'   offspring_mean = 0.5, serial_sampler = function(x) 3
+#' )
 #'
 #' # Simulate with negative binomial offspring
-#' simulate_tree_from_pop(pop = 100, offspring_dist = "nbinom",
-#' offspring_mean = 0.5, offspring_disp = 1.1, serial_sampler = function(x) 3)
+#' simulate_tree_from_pop(
+#'   pop = 100, offspring_dist = "nbinom",
+#'   offspring_mean = 0.5, offspring_disp = 1.1, serial_sampler = function(x) 3
+#' )
 #' @export
 simulate_tree_from_pop <- function(pop,
                                    offspring_dist = c("pois", "nbinom"),
@@ -344,26 +355,26 @@ simulate_tree_from_pop <- function(pop,
 
   if (offspring_dist == "pois") {
     if (!missing(offspring_disp)) {
-      warning(sprintf("%s %s %s",
-                      "'offspring_disp' is not used for",
-                      "poisson offspring distribution.",
-                      "Will be ignored."
-                      )
-              )
+      warning(sprintf(
+        "%s %s %s",
+        "'offspring_disp' is not used for",
+        "poisson offspring distribution.",
+        "Will be ignored."
+      ))
     }
 
     ## using a right truncated poisson distribution
     ## to avoid more cases than susceptibles
     offspring_fun <- get_offspring_func(offspring_dist)
-
   } else if (offspring_dist == "nbinom") {
     if (missing(offspring_disp)) {
       stop(sprintf("%s", "'offspring_disp' must be specified."))
     } else if (offspring_disp <= 1) { ## dispersion coefficient
-      stop(sprintf("%s %s %s",
-                   "Offspring distribution 'nbinom' requires",
-                   "argument 'offspring_disp' > 1.",
-                   "Use 'pois' if there is no overdispersion."
+      stop(sprintf(
+        "%s %s %s",
+        "Offspring distribution 'nbinom' requires",
+        "argument 'offspring_disp' > 1.",
+        "Use 'pois' if there is no overdispersion."
       ))
     }
     offspring_fun <- get_offspring_func(offspring_dist)
@@ -375,7 +386,7 @@ simulate_tree_from_pop <- function(pop,
     ancestor = NA_integer_,
     generation = 1L,
     time = t0,
-    offspring_generated = FALSE #used to track simulation and dropped afterwards
+    offspring_generated = FALSE # tracks simulation and dropped afterwards
   )
 
   susc <- pop - initial_immune - 1L
@@ -384,7 +395,6 @@ simulate_tree_from_pop <- function(pop,
   ## continue if any unsimulated chains have t <= tf
   ## AND there is still susceptibles left
   while (any(tree_df$time[!tree_df$offspring_generated] <= tf) && susc > 0) {
-
     ## select from which case to generate offspring
     t <- min(tree_df$time[!tree_df$offspring_generated]) # lowest unsimulated t
 
@@ -434,7 +444,7 @@ simulate_tree_from_pop <- function(pop,
   ## have been generated in the last generation
   tree_df <- tree_df[tree_df$time <= tf, ]
 
-  #sort by sim_id and ancestor
+  # sort by sim_id and ancestor
   tree_df <- tree_df[order(tree_df$sim_id, tree_df$ancestor), ]
   tree_df$offspring_generated <- NULL
 

--- a/R/stat_likelihoods.R
+++ b/R/stat_likelihoods.R
@@ -60,7 +60,6 @@ gborel_size_ll <- function(x, size, prob, mu) {
 #' @author Sebastian Funk
 #' @keywords internal
 pois_length_ll <- function(x, lambda) {
-
   ## iterated exponential function
   arg <- exp(lambda * exp(-lambda))
   itex <- 1
@@ -106,10 +105,11 @@ geom_length_ll <- function(x, prob) {
 #' @export
 offspring_ll <- function(chains, offspring_dist, statistic,
                          nsim_offspring = 100, log = TRUE, ...) {
-
   # Simulate the chains
-  chains <- simulate_summary(nsim_offspring, offspring_dist,
-                          statistic, ...)
+  chains <- simulate_summary(
+    nsim_offspring, offspring_dist,
+    statistic, ...
+  )
 
   # Compute the empirical Cumulative Distribution Function of the
   # simulated chains

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ The latest development version of the _{{ packagename }}_ package can be install
 
 ```{r include=TRUE,eval=FALSE}
 # check whether {pak} is installed
-if(!require("pak")) install.packages("pak")
+if (!require("pak")) install.packages("pak")
 pak::pak("{{ gh_repo }}")
 ```
 

--- a/man/aggregate.epichains.Rd
+++ b/man/aggregate.epichains.Rd
@@ -25,9 +25,11 @@ Aggregate cases in epichains objects according to a grouping variable
 }
 \examples{
 set.seed(123)
-chains <- simulate_tree(nchains = 10, statistic = "size",
-offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
-lambda = 2)
+chains <- simulate_tree(
+  nchains = 10, statistic = "size",
+  offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
+  lambda = 2
+)
 chains
 
 # Aggregate cases per time

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -66,8 +66,10 @@ Estimate the (log) likelihood for observed branching processes
 \examples{
 # example of observed chain sizes
 chain_sizes <- c(1, 1, 4, 7)
-likelihood(chains = chain_sizes, statistic = "size",
- offspring_dist = "pois", nsim_obs = 100, lambda = 0.5)
+likelihood(
+  chains = chain_sizes, statistic = "size",
+  offspring_dist = "pois", nsim_obs = 100, lambda = 0.5
+)
 }
 \seealso{
 offspring_ll, pois_size_ll, nbinom_size_ll, gborel_size_ll,

--- a/man/simulate_summary.Rd
+++ b/man/simulate_summary.Rd
@@ -35,6 +35,8 @@ computed. Results above the specified value, are set to \code{Inf}.}
 Simulate a summary of the transmission chain statistic
 }
 \examples{
-simulate_summary(nchains = 10, statistic = "size", offspring_dist = "pois",
-stat_max = 10, lambda = 2)
+simulate_summary(
+  nchains = 10, statistic = "size", offspring_dist = "pois",
+  stat_max = 10, lambda = 2
+)
 }

--- a/man/simulate_tree.Rd
+++ b/man/simulate_tree.Rd
@@ -100,9 +100,11 @@ where \code{...} are the other arguments to \code{simulate_tree()}.
 
 \examples{
 set.seed(123)
-chains <- simulate_tree(nchains = 10, statistic = "size",
-offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
-lambda = 2)
+chains <- simulate_tree(
+  nchains = 10, statistic = "size",
+  offspring_dist = "pois", stat_max = 10, serials_sampler = function(x) 3,
+  lambda = 2
+)
 }
 \references{
 Lehtinen S, Ashcroft P, Bonhoeffer S. On the relationship

--- a/man/simulate_tree_from_pop.Rd
+++ b/man/simulate_tree_from_pop.Rd
@@ -73,12 +73,16 @@ simulate_tree_from_pop() has a couple of key different from simulate_tree():
 
 \examples{
 # Simulate with poisson offspring
-simulate_tree_from_pop(pop = 100, offspring_dist = "pois",
-offspring_mean = 0.5, serial_sampler = function(x) 3)
+simulate_tree_from_pop(
+  pop = 100, offspring_dist = "pois",
+  offspring_mean = 0.5, serial_sampler = function(x) 3
+)
 
 # Simulate with negative binomial offspring
-simulate_tree_from_pop(pop = 100, offspring_dist = "nbinom",
-offspring_mean = 0.5, offspring_disp = 1.1, serial_sampler = function(x) 3)
+simulate_tree_from_pop(
+  pop = 100, offspring_dist = "nbinom",
+  offspring_mean = 0.5, offspring_disp = 1.1, serial_sampler = function(x) 3
+)
 }
 \author{
 Flavio Finger

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,3 +1,6 @@
-if (requireNamespace("spelling", quietly = TRUE))
-  spelling::spell_check_test(vignettes = TRUE, error = FALSE,
-                             skip_on_cran = TRUE)
+if (requireNamespace("spelling", quietly = TRUE)) {
+  spelling::spell_check_test(
+    vignettes = TRUE, error = FALSE,
+    skip_on_cran = TRUE
+  )
+}

--- a/tests/testthat/tests-sim.r
+++ b/tests/testthat/tests-sim.r
@@ -1,27 +1,30 @@
 test_that("Simulators output epichains objects", {
   expect_s3_class(
-    simulate_tree(nchains = 10,
-                  offspring_dist = "pois",
-                  lambda = 2,
-                  statistic = "size",
-                  stat_max = 10
-                  ),
-    "epichains"
-    )
-  expect_s3_class(
-    simulate_tree_from_pop(pop = 100,
-                           offspring_dist = "nbinom",
-                           offspring_mean = 0.5,
-                           offspring_disp = 1.1,
-                           serial_sampler = function(x) 3
+    simulate_tree(
+      nchains = 10,
+      offspring_dist = "pois",
+      lambda = 2,
+      statistic = "size",
+      stat_max = 10
     ),
     "epichains"
   )
   expect_s3_class(
-    simulate_summary(n = 10,
-                  offspring_dist = "pois",
-                  lambda = 2,
-                  stat_max = 10
+    simulate_tree_from_pop(
+      pop = 100,
+      offspring_dist = "nbinom",
+      offspring_mean = 0.5,
+      offspring_disp = 1.1,
+      serial_sampler = function(x) 3
+    ),
+    "epichains"
+  )
+  expect_s3_class(
+    simulate_summary(
+      n = 10,
+      offspring_dist = "pois",
+      lambda = 2,
+      stat_max = 10
     ),
     "epichains"
   )

--- a/vignettes/epichains.Rmd
+++ b/vignettes/epichains.Rmd
@@ -65,54 +65,60 @@ knitr::opts_chunk$set(
 ```{r include=TRUE,echo=TRUE}
 library(epichains)
 # Using `simulate_tree()`
-tree_from_pois_offspring <- simulate_tree(nchains = 10,
-                                  offspring_dist = "pois",
-                                  serials_sampler = function(x) 3,
-                                  lambda = 2,
-                                  stat_max = 10
-                                  )
+tree_from_pois_offspring <- simulate_tree(
+  nchains = 10,
+  offspring_dist = "pois",
+  serials_sampler = function(x) 3,
+  lambda = 2,
+  stat_max = 10
+)
 
 tree_from_pois_offspring # print the output
 
 # Using simulate_summary()
-summary_sim <- simulate_summary(nchains = 50, offspring_dist = "pois",
-                                statistic = "length", lambda = 2, 
-                                stat_max = 10)
+summary_sim <- simulate_summary(
+  nchains = 50, offspring_dist = "pois",
+  statistic = "length", lambda = 2,
+  stat_max = 10
+)
 
 summary_sim # print the output
 
 # Using `simulate_tree_from_pop()`
 
 # Simulate with poisson offspring
-tree_from_pop_pois <- simulate_tree_from_pop(pop = 1000,
-                                                offspring_dist = "pois",
-                                                offspring_mean = 0.5,
-                                                serial_sampler = function(x) 3
-                                                )
+tree_from_pop_pois <- simulate_tree_from_pop(
+  pop = 1000,
+  offspring_dist = "pois",
+  offspring_mean = 0.5,
+  serial_sampler = function(x) 3
+)
 
 tree_from_pop_pois # print the output
 
 # Simulate with negative binomial offspring
-tree_from_pop_nbinom <- simulate_tree_from_pop(pop = 1000,
-                                                  offspring_dist = "nbinom",
-                                                  offspring_mean = 0.5,
-                                                  offspring_disp = 1.1,
-                                                  serial_sampler = function(x) 3
-                                                  )
+tree_from_pop_nbinom <- simulate_tree_from_pop(
+  pop = 1000,
+  offspring_dist = "nbinom",
+  offspring_mean = 0.5,
+  offspring_disp = 1.1,
+  serial_sampler = function(x) 3
+)
 
 tree_from_pop_nbinom # print the output
 
 # Likelihoods
 
 chain_sizes <- c(1, 1, 4, 7)
-likelihood(chains = chain_sizes, statistic = "size",
-                    offspring_dist = "pois", nsim_obs = 100,
-                    lambda = 0.5)
+likelihood(
+  chains = chain_sizes, statistic = "size",
+  offspring_dist = "pois", nsim_obs = 100,
+  lambda = 0.5
+)
 ```
 
 ### Aggregation
 ```{r include=TRUE,echo=TRUE}
-
 # aggregate by time
 aggregate(tree_from_pop_pois, "time")
 


### PR DESCRIPTION
This PR is a result of running `styler::style_pkg()` and `lintr::lint_pkg()` iteratively to fix all code style issues. The changes align with the [tidyverse style guide](https://style.tidyverse.org/index.html). 

Additionally, the `indentation_linter` is turned on to catch any indentation issues moving forward. It was [previously turned off](https://github.com/epiverse-trace/epichains/pull/33/commits/30ed39bde6c6b8633e1632b42a49faaeef3389c9) due to some instability issues but has been deemed necessary to be turned back on. 

The PR closes #40. 