### PR TITLE
Fix website

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^pkgdown$
 ^data-raw$
 ^CITATION\.cff$
+^_pkgdown\.yml$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,11 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# Reproduce locally by running:
+# ```r
+# pak::pak(c("any::pkgdown", "."), dependencies = "Config/Needs/website")
+# pkgdown::build_site()
+# ```
 on:
   push:
     branches: [main, master]
@@ -16,7 +22,6 @@ on:
       - '.Rbuildignore'
       - '.github/**'
   pull_request:
-    branches: [main, master]
     paths:
       - 'README.Rmd'
       - 'README.md'
@@ -68,6 +73,11 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          clean: false
+          # We clean on releases because we want to remove old vignettes,
+          # figures, etc. that have been deleted from the `main` branch.
+          # But we clean ONLY on releases because we want to be able to keep
+          # both the 'stable' and 'dev' websites.
+          # Also discussed in https://github.com/r-lib/actions/issues/484
+          clean: ${{ github.event_name == 'release' }}
           branch: gh-pages
           folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ rsconnect/
 /Meta/
 /docs/
 .DS_Store
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ VignetteBuilder:
     knitr
 Remotes:
     github::epiverse-trace/epiparameter
+Config/Needs/website:epiverse-trace/epiversetheme
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: ~
+template:
+  package: epiversetheme
+


### PR DESCRIPTION
This PR sets up the package website and `pkgdown` workflows to conform with the Epiverse-TRACE {packagetemplate}. It closes #53. 