### PR TITLE
Fix bug in summary method 

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -87,7 +87,7 @@ summary.epichains <- function(object, ...) {
   chains_ran <- attr(object, "chains", exact = TRUE)
 
   if (is_chains_tree(object)) {
-    max_time <- max(object$time)
+    max_time <- ifelse(("time" %in% names(object)), max(object$time), NA)
 
     n_unique_ancestors <- length(
       unique(object$ancestor[!is.na(object$ancestor)])

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -103,11 +103,11 @@ summary.epichains <- function(object, ...) {
       max_generation = max_generation
     )
   } else if (is_chains_summary(object)) {
-    if (!all(is.infinite(object))) {
+    if (all(is.infinite(object))) {
+      max_chain_stat <- min_chain_stat <- Inf
+    } else {
       max_chain_stat <- max(object[!is.infinite(object)])
       min_chain_stat <- min(object[!is.infinite(object)])
-    } else {
-      max_chain_stat <- min_chain_stat <- Inf
     }
 
     res <- list(


### PR DESCRIPTION
This PR fixes a bug in the `summary()` where the `max_time = -Inf` because the `<epichains>` object from `simulate_tree()` does not have a `time` column as a result of `serial_dist` not being specified. This closes #69.