### PR TITLE
Remove redundant else block

### DIFF
--- a/R/simulate.r
+++ b/R/simulate.r
@@ -401,8 +401,6 @@ simulate_tree_from_pop <- function(pop,
         size = size
       )
     }
-  } else {
-    stop("offspring_dist must either be 'pois' or 'nbinom'")
   }
 
   ## initializations


### PR DESCRIPTION
This PR removes a redundant `else` block from `simulate_tree_from_pop` that is already accounted for in the argument matching step and has an associated test.