### PR TITLE
Remove conditional inheritance from `aggregate` method

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -240,30 +240,33 @@ tail.epichains <- function(x, ...) {
   utils::tail(as.data.frame(x), ...)
 }
 
-#' Aggregate cases in epichains objects according to a grouping variable
+#' Aggregate cases in `<epichains>` objects by "time" or "generation"
 #'
-#' @param x An [`epichains`] object.
+#' @param x An `<epichains>` object.
 #' @param grouping_var The variable to group and count over. Options include
-#' "time", "generation", and "both".
+#' "time" and "generation".
 #' @param ... Other arguments passed to aggregate.
 #' @importFrom stats aggregate
-#' @return If grouping_var is either "time" or "generation", a data.frame
-#' with cases aggregated over `grouping_var`; If
-#' \code{grouping_var = "both"}, a list of data.frames, the first being for
-#'  cases over time, and the second being for cases over generations.
+#' @return An `<epichains_aggregate_df>` object, which is basically a
+#' `<data.frame>`. The object stores the `chain_type = chains_tree` and
+#' `grouping_var` attributes.
 #' @export
 #' @author James M. Azam
 #' @examples
 #' set.seed(123)
 #' chains <- simulate_tree(
-#'   nchains = 10, statistic = "size",
-#'   offspring_dist = "pois", stat_max = 10, serials_dist = function(x) 3,
+#'   nchains = 10,
+#'   statistic = "size",
+#'   offspring_dist = "pois",
+#'   stat_max = 10,
+#'   serials_dist = function(x) 3,
 #'   lambda = 2
 #' )
 #' chains
 #'
 #' # Aggregate cases per time
-#' aggregate(chains, grouping_var = "time")
+#' cases_per_time <- aggregate(chains, grouping_var = "time")
+#' head(cases_per_time)
 #'
 #' # Aggregate cases per generation
 #' cases_per_gen <- aggregate(chains, grouping_var = "generation")

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -266,15 +266,12 @@ tail.epichains <- function(x, ...) {
 #' aggregate(chains, grouping_var = "time")
 #'
 #' # Aggregate cases per generation
-#' aggregate(chains, grouping_var = "generation")
-#'
-#' # Aggregate cases per both time and generation
-#' aggregate(chains, grouping_var = "both")
+#' cases_per_gen <- aggregate(chains, grouping_var = "generation")
+#' head(cases_per_gen)
 aggregate.epichains <- function(x,
                                 grouping_var = c(
                                   "time",
-                                  "generation",
-                                  "both"
+                                  "generation"
                                 ),
                                 ...) {
   validate_epichains(x)
@@ -302,21 +299,6 @@ aggregate.epichains <- function(x,
       list(cases = x$sim_id),
       list(generation = x$generation),
       FUN = NROW
-    )
-  } else if (grouping_var == "both") {
-    # Count the number of cases per time
-    list(
-      stats::aggregate(
-        list(cases = x$sim_id),
-        list(time = x$time),
-        FUN = NROW
-      ),
-      # Count the number of cases per generation
-      stats::aggregate(
-        list(cases = x$sim_id),
-        list(generation = x$generation),
-        FUN = NROW
-      )
     )
   }
 

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -307,7 +307,7 @@ aggregate.epichains <- function(x,
 
   structure(
     out,
-    class = c("epichains_aggregate_df", class(out)),
+    class = c("epichains_aggregate_df", "data.frame"),
     chain_type = attributes(x)$chain_type,
     rownames = NULL,
     aggregated_over = grouping_var

--- a/man/aggregate.epichains.Rd
+++ b/man/aggregate.epichains.Rd
@@ -4,21 +4,20 @@
 \alias{aggregate.epichains}
 \title{Aggregate cases in epichains objects according to a grouping variable}
 \usage{
-\method{aggregate}{epichains}(x, grouping_var = c("time", "generation", "both"), ...)
+\method{aggregate}{epichains}(x, grouping_var = c("time", "generation"), ...)
 }
 \arguments{
 \item{x}{An \code{\link{epichains}} object.}
 
 \item{grouping_var}{The variable to group and count over. Options include
-"time", "generation", and "both".}
+"time" and "generation".}
 
 \item{...}{Other arguments passed to aggregate.}
 }
 \value{
-If grouping_var is either "time" or "generation", a data.frame
-with cases aggregated over \code{grouping_var}; If
-\code{grouping_var = "both"}, a list of data.frames, the first being for
-cases over time, and the second being for cases over generations.
+An \verb{<epichains_aggregate_df>} object, which is basically a
+\verb{<data.frame>}. The object stores the \code{chain_type = chains_tree} and
+\code{grouping_var} attributes.
 }
 \description{
 Aggregate cases in epichains objects according to a grouping variable

--- a/man/aggregate.epichains.Rd
+++ b/man/aggregate.epichains.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/epichains.R
 \name{aggregate.epichains}
 \alias{aggregate.epichains}
-\title{Aggregate cases in epichains objects according to a grouping variable}
+\title{Aggregate cases in \verb{<epichains>} objects by "time" or "generation"}
 \usage{
 \method{aggregate}{epichains}(x, grouping_var = c("time", "generation"), ...)
 }
 \arguments{
-\item{x}{An \code{\link{epichains}} object.}
+\item{x}{An \verb{<epichains>} object.}
 
 \item{grouping_var}{The variable to group and count over. Options include
 "time" and "generation".}
@@ -20,25 +20,27 @@ An \verb{<epichains_aggregate_df>} object, which is basically a
 \code{grouping_var} attributes.
 }
 \description{
-Aggregate cases in epichains objects according to a grouping variable
+Aggregate cases in \verb{<epichains>} objects by "time" or "generation"
 }
 \examples{
 set.seed(123)
 chains <- simulate_tree(
-  nchains = 10, statistic = "size",
-  offspring_dist = "pois", stat_max = 10, serials_dist = function(x) 3,
+  nchains = 10,
+  statistic = "size",
+  offspring_dist = "pois",
+  stat_max = 10,
+  serials_dist = function(x) 3,
   lambda = 2
 )
 chains
 
 # Aggregate cases per time
-aggregate(chains, grouping_var = "time")
+cases_per_time <- aggregate(chains, grouping_var = "time")
+head(cases_per_time)
 
 # Aggregate cases per generation
-aggregate(chains, grouping_var = "generation")
-
-# Aggregate cases per both time and generation
-aggregate(chains, grouping_var = "both")
+cases_per_gen <- aggregate(chains, grouping_var = "generation")
+head(cases_per_gen)
 }
 \author{
 James M. Azam

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -419,10 +419,6 @@ test_that("aggregate.epichains method returns correct objects", {
     grouping_var = "time"
   )
   aggreg_by_both <- aggregate(
-    tree_sim_raw2,
-    grouping_var = "both"
-  )
-  #' Expectations for <epichains> class inheritance
   expect_true(
     is_epichains_aggregate_df(aggreg_by_gen)
   )
@@ -430,8 +426,6 @@ test_that("aggregate.epichains method returns correct objects", {
     is_epichains_aggregate_df(aggreg_by_time)
   )
   expect_true(
-    is_epichains_aggregate_df(aggreg_by_both)
-  )
   #' Expectations for <base> class inheritance
   expect_s3_class(
     aggreg_by_gen,

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -418,20 +418,20 @@ test_that("aggregate.epichains method returns correct objects", {
     tree_sim_raw2,
     grouping_var = "time"
   )
-  aggreg_by_both <- aggregate(
+  #' Expectations for <epichains_aggregate_df> class inheritance
   expect_true(
     is_epichains_aggregate_df(aggreg_by_gen)
   )
   expect_true(
     is_epichains_aggregate_df(aggreg_by_time)
   )
-  expect_true(
+  expect_named(
     aggreg_by_gen,
-    "data.frame"
+    c("generation", "cases")
   )
-  expect_s3_class(
+  expect_named(
     aggreg_by_time,
-    "data.frame"
+    c("time", "cases")
   )
 })
 

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -435,7 +435,7 @@ test_that("aggregate.epichains method returns correct objects", {
   )
 })
 
-test_that("aggregate method is numerically correct", {
+test_that("aggregate.epichains method is numerically correct", {
   set.seed(12)
   #' Simulate a tree of infections without serials
   tree_sim_raw <- simulate_tree(

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -426,18 +426,12 @@ test_that("aggregate.epichains method returns correct objects", {
     is_epichains_aggregate_df(aggreg_by_time)
   )
   expect_true(
-  #' Expectations for <base> class inheritance
-  expect_s3_class(
     aggreg_by_gen,
     "data.frame"
   )
   expect_s3_class(
     aggreg_by_time,
     "data.frame"
-  )
-  expect_s3_class(
-    aggreg_by_both,
-    "list"
   )
 })
 

--- a/vignettes/epichains.Rmd
+++ b/vignettes/epichains.Rmd
@@ -124,7 +124,4 @@ aggregate(tree_from_pop_pois, "time")
 
 # aggregate by generation
 aggregate(tree_from_pop_pois, "generation")
-
-# aggregate by both time and generation
-aggregate(tree_from_pop_pois, "both")
 ```


### PR DESCRIPTION
This PR closes #72 by removing the option to pass "both" to the `grouping_var` argument. 

This will prevent the issue raised in #79 where there is conditional inheritance in the `<epichains_aggregate_df>` class so that it can either be a subclass of `<data.frame>` or `<list>` depending on the value of `grouping_var`. 

The option for "both" was just for convenient but creates more problems than it solves.