### PR TITLE
Improve `aggregate` method to deal with unavailable "time" column

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -290,6 +290,13 @@ aggregate.epichains <- function(x,
   grouping_var <- match.arg(grouping_var)
 
   out <- if (grouping_var == "time") {
+    if (is.null(x$time)) {
+      stop(
+        "Object must have a time column. ",
+        "To simulate time, specify `serials_dist` ",
+        "in the `simulate_tree()` setup."
+      )
+    }
     # Count the number of cases per generation
     stats::aggregate(
       list(cases = x$sim_id),

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -435,6 +435,22 @@ test_that("aggregate.epichains method returns correct objects", {
   )
 })
 
+test_that("aggregate.epichains method throws errors", {
+  expect_error(
+    aggregate(
+      simulate_tree(
+        nchains = 10,
+        statistic = "size",
+        offspring_dist = "pois",
+        stat_max = 10,
+        lambda = 2
+      ),
+      grouping_var = "time"
+    ),
+    "Object must have a time column"
+  )
+})
+
 test_that("aggregate.epichains method is numerically correct", {
   set.seed(12)
   #' Simulate a tree of infections without serials


### PR DESCRIPTION
This PR closes #80 by throwing an error when `aggregate(x, grouping_var = "both")` is called but the "time" column does not exist in the `<epichains>` object passed.