### PR TITLE
Improve summary method

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -33,7 +33,7 @@ format.epichains <- function(x, ...) {
     # print summary information
     writeLines(
       c(
-        sprintf("Chains simulated: %s", chain_info[["chains_ran"]]),
+        sprintf("Chains simulated: %s", chain_info[["chains_run"]]),
         sprintf(
           "Number of ancestors (known): %s",
           chain_info[["unique_ancestors"]]
@@ -84,7 +84,7 @@ format.epichains <- function(x, ...) {
 summary.epichains <- function(object, ...) {
   validate_epichains(object)
 
-  chains_ran <- attr(object, "chains", exact = TRUE)
+  chains_run <- attr(object, "chains", exact = TRUE)
 
   if (is_chains_tree(object)) {
     max_time <- ifelse(("time" %in% names(object)), max(object$time), NA)
@@ -97,7 +97,7 @@ summary.epichains <- function(object, ...) {
 
     # out of summary
     res <- list(
-      chains_ran = chains_ran,
+      chains_run = chains_run,
       max_time = max_time,
       unique_ancestors = n_unique_ancestors,
       max_generation = max_generation
@@ -111,7 +111,7 @@ summary.epichains <- function(object, ...) {
     }
 
     res <- list(
-      chain_ran = chains_ran,
+      chains_run = chains_run,
       max_chain_stat = max_chain_stat,
       min_chain_stat = min_chain_stat
     )

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -167,7 +167,7 @@ test_that("summary.epichains works as expected", {
   expect_named(
     summary(tree_sim_raw),
     c(
-      "chains_ran",
+      "chains_run",
       "max_time",
       "unique_ancestors",
       "max_generation"
@@ -176,7 +176,7 @@ test_that("summary.epichains works as expected", {
   expect_named(
     summary(tree_sim_raw2),
     c(
-      "chains_ran",
+      "chains_run",
       "max_time",
       "unique_ancestors",
       "max_generation"
@@ -185,7 +185,7 @@ test_that("summary.epichains works as expected", {
   expect_named(
     summary(susc_outbreak_raw),
     c(
-      "chains_ran",
+      "chains_run",
       "max_time",
       "unique_ancestors",
       "max_generation"
@@ -194,7 +194,7 @@ test_that("summary.epichains works as expected", {
   expect_named(
     summary(susc_outbreak_raw2),
     c(
-      "chains_ran",
+      "chains_run",
       "max_time",
       "unique_ancestors",
       "max_generation"
@@ -203,7 +203,7 @@ test_that("summary.epichains works as expected", {
   expect_named(
     summary(chain_summary_raw),
     c(
-      "chain_ran",
+      "chains_run",
       "max_chain_stat",
       "min_chain_stat"
     )

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -347,7 +347,7 @@ test_that("simulate_tree is numerically correct", {
   tree_sim_intvn_summary <- summary(tree_sim_raw_intvn)
   #' Expectations
   expect_identical(
-    tree_sim_summary$chains_ran,
+    tree_sim_summary$chains_run,
     2.00
   )
   expect_identical(
@@ -376,7 +376,7 @@ test_that("simulate_tree is numerically correct", {
   )
   #' Expectations for intervention simulation
   expect_identical(
-    tree_sim_summary$chains_ran,
+    tree_sim_summary$chains_run,
     2.0
   )
   expect_identical(
@@ -427,7 +427,7 @@ test_that("simulate_summary is numerically correct", {
   chain_summary_intvn_summaries <- summary(chain_summary_raw_intvn)
   #' Expectations
   expect_identical(
-    chain_summary_summaries$chain_ran,
+    chain_summary_summaries$chains_run,
     2.00
   )
   expect_identical(
@@ -443,7 +443,7 @@ test_that("simulate_summary is numerically correct", {
     c(1.00, 3.00)
   )
   expect_identical(
-    chain_summary_intvn_summaries$chain_ran,
+    chain_summary_intvn_summaries$chains_run,
     2.00
   )
   expect_identical(
@@ -495,7 +495,7 @@ test_that("simulate_tree_from_pop is numerically correct", {
     susc_outbreak_summary$max_generation,
     1L
   )
-  expect_null(susc_outbreak_summary$chains_ran)
+  expect_null(susc_outbreak_summary$chains_run)
   expect_identical(
     susc_outbreak_raw$sim_id,
     1L
@@ -528,7 +528,7 @@ test_that("simulate_tree_from_pop is numerically correct", {
     susc_outbreak_summary_intvn$max_generation,
     10L
   )
-  expect_null(susc_outbreak_summary_intvn$chains_ran)
+  expect_null(susc_outbreak_summary_intvn$chains_run)
   expect_identical(
     sum(aggregate(susc_outbreak_raw_intvn, "time")$cases),
     20L


### PR DESCRIPTION
This PR renames chains_ran to chains_run. It also fixes an inconsistency in the same variable in the summary method for <chains_summary> objects by returning the same variable name across the classes