### PR TITLE
Sum loglikelihoods before exponentiating

### DIFF
--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -134,17 +134,19 @@ likelihood <- function(chains, statistic = c("size", "length"), offspring_dist,
     likelihoods[sx[!(sx %in% exclude)]]
   })
 
-  ## transform log-likelihoods into likelihoods if required
-  if (isFALSE(log)) {
-    chains_likelihood <- lapply(chains_likelihood, exp)
+  ## if individual == FALSE, return the joint log-likelihood
+  ## (sum of the log-likelihoods)
+  if (!individual) {
+    chains_likelihood <- vapply(chains_likelihood, sum, 0)
   }
 
-  ## if individual == FALSE, return the joint log-likelihood
-  ## (sum of the log-likelihoods), if log == TRUE, else
-  ## multiply the likelihoods
-  if (isFALSE(individual)) {
-    summarise_func <- ifelse(log, sum, prod)
-    chains_likelihood <- vapply(chains_likelihood, summarise_func, 0)
+  ## transform log-likelihoods into likelihoods if required
+  if (!log) {
+    if (individual) {
+      chains_likelihood <- lapply(chains_likelihood, exp)
+    } else {
+      chains_likelihood <- exp(chains_likelihood)
+    }
   }
 
   return(chains_likelihood)


### PR DESCRIPTION
Order of operations at the end of likelihood() has been switched, which highlighted the opportunity to use a vectorized exp() call in some cases.

The new code should be:

## Faster (when `log = FALSE, individual = FALSE`)

``` r
library(microbenchmark)
library(epichains)

# randomly generate 20 chains of size 1 to 10
chain_sizes <- sample(1:10, 100, replace = TRUE)

microbenchmark(
  likelihood(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, obs_prob = 0.5
  ),
  likelihood_old(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, obs_prob = 0.5
  ),
  times = 1e3
)
#> Unit: milliseconds
#>                                                                                                                                    expr
#>      likelihood(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, obs_prob = 0.5)
#>  likelihood_old(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, obs_prob = 0.5)
#>       min       lq     mean   median       uq      max neval
#>  273.8103 312.9286 341.6483 332.5475 357.6596 609.6394  1000
#>  277.9916 312.7059 340.9575 332.5310 357.6125 589.5059  1000

microbenchmark(
  likelihood(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, log = FALSE, obs_prob = 0.5
  ),
  likelihood_old(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, log = FALSE, obs_prob = 0.5
  ),
  times = 1e3
)
#> Unit: milliseconds
#>                                                                                                                                                 expr
#>      likelihood(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, log = FALSE, obs_prob = 0.5)
#>  likelihood_old(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, log = FALSE, obs_prob = 0.5)
#>       min       lq     mean   median       uq      max neval
#>  280.8126 318.0650 351.5412 339.0232 366.4869 712.5673  1000
#>  295.8321 327.4035 363.9978 348.9071 373.9444 685.0759  1000

microbenchmark(
  likelihood(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, log = FALSE,
    individual = TRUE, obs_prob = 0.5
  ),
  likelihood_old(
    chains = chain_sizes, statistic = "size",
    offspring_dist = "pois", nsim_obs = 1e4, lambda = 0.5, log = FALSE,
    individual = TRUE, obs_prob = 0.5
  ),
  times = 1e3
)
#> Unit: milliseconds
#>                                                                                                                                                                         expr
#>      likelihood(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, log = FALSE, individual = TRUE,      obs_prob = 0.5)
#>  likelihood_old(chains = chain_sizes, statistic = "size", offspring_dist = "pois",      nsim_obs = 10000, lambda = 0.5, log = FALSE, individual = TRUE,      obs_prob = 0.5)
#>       min       lq     mean   median       uq      max neval
#>  287.1338 308.0223 334.6865 335.8227 355.4666 544.8965  1000
#>  286.0165 306.2436 334.0689 333.8073 353.5573 664.2069  1000
```

<sup>Created on 2023-11-06 with reprex v2.0.2</sup>

## More robust

It is often problematic to work with very small values, such as the ones produced by exponentiating a large negative number. This can lead to [underflows](https://en.wikipedia.org/wiki/Arithmetic_underflow).
This is one of the reasons why we use log likelihood, as discussed in this [SO thread](https://math.stackexchange.com/questions/892832/why-we-consider-log-likelihood-instead-of-likelihood-in-gaussian-distribution).

## Simpler

An `ifelse()` has been removed.

# Note

This seems like a minimal improvement so submitting this as a draft PR to get opinions. I'm fine with whatever the outcome of this PR is (closed without merging or merged).