### PR TITLE
not for merging: benchmark options for binding data frames in simulation

### DIFF
--- a/benchmark.r
+++ b/benchmark.r
@@ -1,7 +1,7 @@
-library("microbenchmark")
+library("bench")
 library("data.table")
 devtools::load_all()
-source("simulate_benchmark.r" )
+source("simulate_benchmark.r")
 
 args <- list(
   nchains = 10,
@@ -11,23 +11,17 @@ args <- list(
   lambda = 2
 )
 
-microbenchmark(
-  do.call(simulate_tree, c(args, stat_max = 100)),
-  do.call(simulate_tree_do_call, c(args, stat_max = 100)),
-  do.call(simulate_tree_rbindlist, c(args, stat_max = 100)),
-  times = 100
+bnmk <- bench::press(
+  stat_max = c(1E2, 1E3, 1E4),
+  {
+    bench::mark(
+      simulate_tree = do.call(simulate_tree, c(args, stat_max = stat_max)),
+      simulate_summary = do.call(simulate_summary, c(modifyList(args, list(serials_dist = NULL)), stat_max = stat_max)),
+      simulate_tree_do_call = do.call(simulate_tree_do_call, c(args, stat_max = stat_max)),
+      simulate_tree_rbindlist = do.call(simulate_tree_rbindlist, c(args, stat_max = stat_max)),
+      check = FALSE
+    )
+  }
 )
 
-microbenchmark(
-  do.call(simulate_tree, c(args, stat_max = 1000)),
-  do.call(simulate_tree_do_call, c(args, stat_max = 1000)),
-  do.call(simulate_tree_rbindlist, c(args, stat_max = 1000)),
-  times = 100
-)
-
-microbenchmark(
-  do.call(simulate_tree, c(args, stat_max = 10000)),
-  do.call(simulate_tree_do_call, c(args, stat_max = 10000)),
-  do.call(simulate_tree_rbindlist, c(args, stat_max = 10000)),
-  times = 100
-)
+ggplot2::autoplot(bnmk)

--- a/benchmark.r
+++ b/benchmark.r
@@ -1,0 +1,33 @@
+library("microbenchmark")
+library("data.table")
+devtools::load_all()
+source("simulate_benchmark.r" )
+
+args <- list(
+  nchains = 10,
+  statistic = "size",
+  offspring_dist = "pois",
+  serials_dist = function(n) rep(3, n),
+  lambda = 2
+)
+
+microbenchmark(
+  do.call(simulate_tree, c(args, stat_max = 100)),
+  do.call(simulate_tree_do_call, c(args, stat_max = 100)),
+  do.call(simulate_tree_rbindlist, c(args, stat_max = 100)),
+  times = 100
+)
+
+microbenchmark(
+  do.call(simulate_tree, c(args, stat_max = 1000)),
+  do.call(simulate_tree_do_call, c(args, stat_max = 1000)),
+  do.call(simulate_tree_rbindlist, c(args, stat_max = 1000)),
+  times = 100
+)
+
+microbenchmark(
+  do.call(simulate_tree, c(args, stat_max = 10000)),
+  do.call(simulate_tree_do_call, c(args, stat_max = 10000)),
+  do.call(simulate_tree_rbindlist, c(args, stat_max = 10000)),
+  times = 100
+)

--- a/simulate_benchmark.r
+++ b/simulate_benchmark.r
@@ -1,0 +1,309 @@
+simulate_tree_do_call <- function(nchains, statistic = c("size", "length"),
+                          offspring_dist, stat_max = Inf,
+                          serials_dist, t0 = 0,
+                          tf = Inf, ...) {
+  statistic <- match.arg(statistic)
+
+  # Input checking
+  check_nchains_valid(nchains = nchains)
+  checkmate::assert_character(statistic)
+
+  # check that offspring is properly specified
+  check_offspring_valid(offspring_dist)
+
+  # check that offspring function exists in base R
+  roffspring_name <- paste0("r", offspring_dist)
+  check_offspring_func_valid(roffspring_name)
+
+  checkmate::assert_number(
+    stat_max, lower = 0
+  )
+
+  if (!missing(serials_dist)) {
+    check_serial_valid(serials_dist)
+  }
+  checkmate::assert_numeric(
+    t0, lower = 0, finite = TRUE
+  )
+  checkmate::assert_number(
+    tf, lower = 0
+  )
+
+  # Gather offspring distribution parameters
+  pars <- list(...)
+
+  if (!missing(serials_dist)) {
+    check_serial_valid(serials_dist)
+  } else if (!missing(tf)) {
+    stop("If `tf` is specified, `serials_dist` must be specified too.")
+  }
+
+  # Initialisations
+  stat_track <- rep(1, nchains) # track length or size (depending on `statistic`) #nolint
+  n_offspring <- rep(1, nchains) # current number of offspring
+  sim <- seq_len(nchains) # track chains that are still being simulated
+  ancestor_ids <- rep(1, nchains) # all chains start in generation 1
+
+  # initialise data frame to hold the transmission trees
+  generation <- 1L
+  tree_df <- list(data.frame(
+    chain_id = seq_len(nchains),
+    sim_id = 1L,
+    ancestor = NA_integer_,
+    generation = generation
+  ))
+
+  if (!missing(serials_dist)) {
+    tree_df[[generation]]$time <- t0
+    times <- tree_df[[generation]]$time
+  }
+
+  # next, simulate n chains
+  while (length(sim) > 0) {
+    # simulate next generation
+    next_gen <- do.call(
+      get(roffspring_name),
+      c(
+        list(n = sum(n_offspring[sim])),
+        pars
+      )
+    )
+    if (any(next_gen %% 1 > 0)) {
+      stop("Offspring distribution must return integers")
+    }
+
+    # record indices corresponding to the number of offspring
+    indices <- rep(sim, n_offspring[sim])
+
+    # initialise placeholder for the number of offspring
+    n_offspring <- rep(0, nchains)
+    # assign offspring sum to indices still being simulated
+    n_offspring[sim] <- tapply(next_gen, indices, sum)
+
+    # track size/length
+    stat_track <- update_chain_stat(
+      stat_type = statistic,
+      stat_latest = stat_track,
+      n_offspring = n_offspring
+    )
+
+    # record times/ancestors
+    if (sum(n_offspring[sim]) > 0) {
+      ancestors <- rep(ancestor_ids, next_gen)
+      current_max_id <- unname(tapply(ancestor_ids, indices, max))
+      indices <- rep(sim, n_offspring[sim])
+
+      # create new ids
+      ids <- rep(current_max_id, n_offspring[sim]) +
+        unlist(lapply(n_offspring[sim], seq_len))
+
+      # increment the generation
+      generation <- generation + 1L
+
+      # store new simulation results
+      tree_df[[generation]] <-
+        data.frame(
+          chain_id = indices,
+          sim_id = ids,
+          ancestor = ancestors,
+          generation = generation
+        )
+
+      # if a serial interval model/function was specified, use it
+      # to generate serial intervals for the cases
+      if (!missing(serials_dist)) {
+        times <- rep(times, next_gen) + serials_dist(sum(n_offspring))
+        current_min_time <- unname(tapply(times, indices, min))
+        tree_df[[generation]]$time <- times
+      }
+    }
+
+    ## only continue to simulate chains that have offspring and aren't of
+    ## the specified maximum size/length
+    sim <- which(n_offspring > 0 & stat_track < stat_max)
+    if (length(sim) > 0) {
+      if (!missing(serials_dist)) {
+        ## only continue to simulate chains that don't go beyond tf
+        sim <- intersect(sim, unique(indices)[current_min_time < tf])
+      }
+      if (!missing(serials_dist)) {
+        times <- times[indices %in% sim]
+      }
+      ancestor_ids <- ids[indices %in% sim]
+    }
+  }
+
+  ## bind results together
+  tree_df <- do.call(rbind, tree_df)
+
+  if (!missing(tf)) {
+    tree_df <- tree_df[tree_df$time < tf, ]
+  }
+
+  # sort by sim_id and ancestor
+  tree_df <- tree_df[order(tree_df$sim_id, tree_df$ancestor), ]
+
+  structure(
+    tree_df,
+    chains = nchains,
+    chain_type = "chains_tree",
+    rownames = NULL,
+    track_pop = FALSE,
+    class = c("epichains", "data.frame")
+  )
+}
+
+simulate_tree_rbindlist <- function(nchains, statistic = c("size", "length"),
+                          offspring_dist, stat_max = Inf,
+                          serials_dist, t0 = 0,
+                          tf = Inf, ...) {
+  statistic <- match.arg(statistic)
+
+  # Input checking
+  check_nchains_valid(nchains = nchains)
+  checkmate::assert_character(statistic)
+
+  # check that offspring is properly specified
+  check_offspring_valid(offspring_dist)
+
+  # check that offspring function exists in base R
+  roffspring_name <- paste0("r", offspring_dist)
+  check_offspring_func_valid(roffspring_name)
+
+  checkmate::assert_number(
+    stat_max, lower = 0
+  )
+
+  if (!missing(serials_dist)) {
+    check_serial_valid(serials_dist)
+  }
+  checkmate::assert_numeric(
+    t0, lower = 0, finite = TRUE
+  )
+  checkmate::assert_number(
+    tf, lower = 0
+  )
+
+  # Gather offspring distribution parameters
+  pars <- list(...)
+
+  if (!missing(serials_dist)) {
+    check_serial_valid(serials_dist)
+  } else if (!missing(tf)) {
+    stop("If `tf` is specified, `serials_dist` must be specified too.")
+  }
+
+  # Initialisations
+  stat_track <- rep(1, nchains) # track length or size (depending on `statistic`) #nolint
+  n_offspring <- rep(1, nchains) # current number of offspring
+  sim <- seq_len(nchains) # track chains that are still being simulated
+  ancestor_ids <- rep(1, nchains) # all chains start in generation 1
+
+  # initialise data frame to hold the transmission trees
+  generation <- 1L
+  tree_df <- list(data.table(
+    chain_id = seq_len(nchains),
+    sim_id = 1L,
+    ancestor = NA_integer_,
+    generation = generation
+  ))
+
+  if (!missing(serials_dist)) {
+    tree_df[[generation]]$time <- t0
+    times <- tree_df[[generation]]$time
+  }
+
+  # next, simulate n chains
+  while (length(sim) > 0) {
+    # simulate next generation
+    next_gen <- do.call(
+      get(roffspring_name),
+      c(
+        list(n = sum(n_offspring[sim])),
+        pars
+      )
+    )
+    if (any(next_gen %% 1 > 0)) {
+      stop("Offspring distribution must return integers")
+    }
+
+    # record indices corresponding to the number of offspring
+    indices <- rep(sim, n_offspring[sim])
+
+    # initialise placeholder for the number of offspring
+    n_offspring <- rep(0, nchains)
+    # assign offspring sum to indices still being simulated
+    n_offspring[sim] <- tapply(next_gen, indices, sum)
+
+    # track size/length
+    stat_track <- update_chain_stat(
+      stat_type = statistic,
+      stat_latest = stat_track,
+      n_offspring = n_offspring
+    )
+
+    # record times/ancestors
+    if (sum(n_offspring[sim]) > 0) {
+      ancestors <- rep(ancestor_ids, next_gen)
+      current_max_id <- unname(tapply(ancestor_ids, indices, max))
+      indices <- rep(sim, n_offspring[sim])
+
+      # create new ids
+      ids <- rep(current_max_id, n_offspring[sim]) +
+        unlist(lapply(n_offspring[sim], seq_len))
+
+      # increment the generation
+      generation <- generation + 1L
+
+      # store new simulation results
+      tree_df[[generation]] <-
+        data.table(
+          chain_id = indices,
+          sim_id = ids,
+          ancestor = ancestors,
+          generation = generation
+        )
+
+      # if a serial interval model/function was specified, use it
+      # to generate serial intervals for the cases
+      if (!missing(serials_dist)) {
+        times <- rep(times, next_gen) + serials_dist(sum(n_offspring))
+        current_min_time <- unname(tapply(times, indices, min))
+        tree_df[[generation]]$time <- times
+      }
+    }
+
+    ## only continue to simulate chains that have offspring and aren't of
+    ## the specified maximum size/length
+    sim <- which(n_offspring > 0 & stat_track < stat_max)
+    if (length(sim) > 0) {
+      if (!missing(serials_dist)) {
+        ## only continue to simulate chains that don't go beyond tf
+        sim <- intersect(sim, unique(indices)[current_min_time < tf])
+      }
+      if (!missing(serials_dist)) {
+        times <- times[indices %in% sim]
+      }
+      ancestor_ids <- ids[indices %in% sim]
+    }
+  }
+
+  ## bind results together
+  tree_df <- rbindlist(tree_df)
+
+  if (!missing(tf)) {
+    tree_df <- tree_df[tree_df$time < tf, ]
+  }
+
+  # sort by sim_id and ancestor
+  tree_df <- tree_df[order(tree_df$sim_id, tree_df$ancestor), ]
+
+  structure(
+    tree_df,
+    chains = nchains,
+    chain_type = "chains_tree",
+    rownames = NULL,
+    track_pop = FALSE,
+    class = c("epichains", "data.frame")
+  )
+}


### PR DESCRIPTION
This PR is to explore and decide on a better option for concatenating data frames in the simulation code. See #8 which could be closed in a follow-up PR implementing either of the solutions presented here.

The code in `benchmark.r` explores three options:

1. existing
2. appending `data.frame`s into a list and `rbind` at the end
3. appending `data.table`s into a list and `rbindlist` at the end.

There is a speedup from (2) compared to (1), and even more of one from (3). As one would expect, the relative improvement is greater the longer the simulation.

My inclination would be to go with option (2) so as not to take on any additional dependency.

``` r
library("microbenchmark")
library("data.table")
devtools::load_all()
#> ℹ Loading epichains
source("simulate_benchmark.r" )

args <- list(
  nchains = 10,
  statistic = "size",
  offspring_dist = "pois",
  serials_dist = function(n) rep(3, n),
  lambda = 2
)

microbenchmark(
  do.call(simulate_tree, c(args, stat_max = 100)),
  do.call(simulate_tree_do_call, c(args, stat_max = 100)),
  do.call(simulate_tree_rbindlist, c(args, stat_max = 100)),
  times = 100
)
#> Unit: milliseconds
#>                                                       expr      min       lq
#>            do.call(simulate_tree, c(args, stat_max = 100)) 4.541210 5.519922
#>    do.call(simulate_tree_do_call, c(args, stat_max = 100)) 3.464844 4.605232
#>  do.call(simulate_tree_rbindlist, c(args, stat_max = 100)) 3.109387 3.869115
#>      mean   median       uq      max neval
#>  6.985533 6.253236 7.133548 36.19406   100
#>  6.001265 5.186450 5.956118 48.67011   100
#>  5.066607 4.347425 4.958727 63.18680   100

microbenchmark(
  do.call(simulate_tree, c(args, stat_max = 1000)),
  do.call(simulate_tree_do_call, c(args, stat_max = 1000)),
  do.call(simulate_tree_rbindlist, c(args, stat_max = 1000)),
  times = 100
)
#> Unit: milliseconds
#>                                                        expr      min        lq
#>            do.call(simulate_tree, c(args, stat_max = 1000)) 8.846933 11.122516
#>    do.call(simulate_tree_do_call, c(args, stat_max = 1000)) 7.054560  8.886056
#>  do.call(simulate_tree_rbindlist, c(args, stat_max = 1000)) 6.263210  7.998559
#>      mean    median       uq      max neval
#>  14.10216 12.207483 14.89934 85.52560   100
#>  10.12646  9.792949 10.67190 16.34066   100
#>   9.51944  8.704849 10.12831 23.67870   100

microbenchmark(
  do.call(simulate_tree, c(args, stat_max = 10000)),
  do.call(simulate_tree_do_call, c(args, stat_max = 10000)),
  do.call(simulate_tree_rbindlist, c(args, stat_max = 10000)),
  times = 100
)
#> Unit: milliseconds
#>                                                         expr      min       lq
#>            do.call(simulate_tree, c(args, stat_max = 10000)) 36.89634 64.36803
#>    do.call(simulate_tree_do_call, c(args, stat_max = 10000)) 24.79615 48.93295
#>  do.call(simulate_tree_rbindlist, c(args, stat_max = 10000)) 25.70781 42.62767
#>      mean   median       uq      max neval
#>  84.59559 76.31640 91.31824 185.0550   100
#>  64.99087 55.38497 64.81542 149.8825   100
#>  54.21192 48.34936 54.85450 128.7041   100
```

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>