### PR TITLE
Revise structure of returned `<epichains>` object

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -35,8 +35,8 @@ format.epichains <- function(x, ...) {
       c(
         sprintf("Chains simulated: %s", chain_info[["chains_run"]]),
         sprintf(
-          "Number of ancestors (known): %s",
-          chain_info[["unique_ancestors"]]
+          "Number of infectors (known): %s",
+          chain_info[["unique_infectors"]]
         ),
         sprintf(
           "Number of generations: %s", chain_info[["max_generation"]]
@@ -89,8 +89,8 @@ summary.epichains <- function(object, ...) {
   if (is_chains_tree(object)) {
     max_time <- ifelse(("time" %in% names(object)), max(object$time), NA)
 
-    n_unique_ancestors <- length(
-      unique(object$ancestor[!is.na(object$ancestor)])
+    n_unique_infectors <- length(
+      unique(object$infector_id[!is.na(object$infector_id)])
     )
 
     max_generation <- max(object$generation)
@@ -99,7 +99,7 @@ summary.epichains <- function(object, ...) {
     res <- list(
       chains_run = chains_run,
       max_time = max_time,
-      unique_ancestors = n_unique_ancestors,
+      unique_infectors = n_unique_infectors,
       max_generation = max_generation
     )
   } else if (is_chains_summary(object)) {
@@ -160,12 +160,12 @@ validate_epichains <- function(x) {
   if (is_chains_tree(x)) {
     stopifnot(
       "object does not contain the correct columns" =
-        c("sim_id", "ancestor", "generation") %in%
+        c("sim_id", "infector_id", "generation") %in%
         colnames(x),
       "column `sim_id` must be a numeric" =
         is.numeric(x$sim_id),
-      "column `ancestor` must be a numeric" =
-        is.numeric(x$ancestor),
+      "column `infector_id` must be a numeric" =
+        is.numeric(x$infector_id),
       "column `generation` must be a numeric" =
         is.numeric(x$generation)
     )
@@ -212,14 +212,14 @@ is_chains_summary <- function(x) {
 #' @export
 #' @details
 #' This returns the top rows of an `epichains` object. Note that the object
-#' is originally sorted by `sim_id` and `ancestor` and the first
+#' is originally sorted by `sim_id` and `infector_id` and the first
 #' unknown ancestors (NA) have been dropped from
 #' printing method. To view the full output, use `as.data.frame(<object_name>)`.
 #'
 head.epichains <- function(x, ...) {
-  writeLines("< tree head (from first known ancestor) >\n")
-  # print head of the simulation output from the first known ancestor
-  x <- x[!is.na(x$ancestor), ]
+  writeLines("< tree head (from first known infector) >\n")
+  # print head of the simulation output from the first known infector
+  x <- x[!is.na(x$infector_id), ]
   utils::head(as.data.frame(x), ...)
 }
 
@@ -231,8 +231,8 @@ head.epichains <- function(x, ...) {
 #' @author James M. Azam
 #' @export
 #' @details
-#' This returns the top rows of an `epichains` object. Note that the object
-#' is originally sorted by `sim_id` and `ancestor` and the first
+#' This returns the bottom part of an `epichains` object. Note that the object
+#' is originally sorted by `sim_id` and `infector_id` and the first
 #' unknown ancestors (NA) have been dropped from
 #' printing method. To view the full output, use `as.data.frame(<object_name>)`.
 tail.epichains <- function(x, ...) {

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -252,7 +252,7 @@ simulate_tree <- function(ntrees, statistic = c("size", "length"),
 
   # sort by sim_id and infector
   tree_df <- tree_df[order(tree_df$sim_id, tree_df$infector_id), ]
-
+  row.names(tree_df) <- NULL
   structure(
     tree_df,
     chains = ntrees,
@@ -562,7 +562,7 @@ simulate_tree_from_pop <- function(pop,
   # sort by sim_id and infector
   tree_df <- tree_df[order(tree_df$sim_id, tree_df$infector_id), ]
   tree_df$offspring_generated <- NULL
-
+  row.names(tree_df) <- NULL
   structure(
     tree_df,
     chain_type = "chains_tree",

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -154,7 +154,7 @@ simulate_tree <- function(ntrees, statistic = c("size", "length"),
   stat_track <- rep(1, ntrees) # track length or size (depending on `statistic`) #nolint
   n_offspring <- rep(1, ntrees) # current number of offspring
   sim <- seq_len(ntrees) # track chains that are still being simulated
-  ancestor_ids <- rep(1, ntrees) # all chains start in generation 1
+  infector_ids <- rep(1, ntrees) # all chains start in generation 1
 
   # initialise data frame to hold the transmission trees
   generation <- 1L

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -159,7 +159,7 @@ simulate_tree <- function(ntrees, statistic = c("size", "length"),
   # initialise data frame to hold the transmission trees
   generation <- 1L
   tree_df <- data.frame(
-    chain_id = seq_len(ntrees),
+    infectee_id = seq_len(ntrees),
     sim_id = 1L,
     infector_id = NA_integer_,
     generation = generation

--- a/man/head.epichains.Rd
+++ b/man/head.epichains.Rd
@@ -19,7 +19,7 @@ object of class \code{data.frame}
 }
 \details{
 This returns the top rows of an \code{epichains} object. Note that the object
-is originally sorted by \code{sim_id} and \code{ancestor} and the first
+is originally sorted by \code{sim_id} and \code{infector_id} and the first
 unknown ancestors (NA) have been dropped from
 printing method. To view the full output, use \verb{as.data.frame(<object_name>)}.
 }

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -25,7 +25,7 @@ determine stopping criteria for simulations when \code{stat_max} is finite.
 Can be one of:
 \itemize{
 \item "size": the total number of offspring.
-\item "length": the total number of ancestors.
+\item "length": the total number of infectors.
 }}
 
 \item{offspring_dist}{Offspring distribution: a character string

--- a/man/offspring_ll.Rd
+++ b/man/offspring_ll.Rd
@@ -20,7 +20,7 @@ determine stopping criteria for simulations when \code{stat_max} is finite.
 Can be one of:
 \itemize{
 \item "size": the total number of offspring.
-\item "length": the total number of ancestors.
+\item "length": the total number of infectors.
 }}
 
 \item{nsim_offspring}{Number of simulations of the offspring distribution

--- a/man/simulate_summary.Rd
+++ b/man/simulate_summary.Rd
@@ -20,7 +20,7 @@ determine stopping criteria for simulations when \code{stat_max} is finite.
 Can be one of:
 \itemize{
 \item "size": the total number of offspring.
-\item "length": the total number of ancestors.
+\item "length": the total number of infectors.
 }}
 
 \item{offspring_dist}{Offspring distribution: a character string

--- a/man/simulate_tree.Rd
+++ b/man/simulate_tree.Rd
@@ -23,7 +23,7 @@ determine stopping criteria for simulations when \code{stat_max} is finite.
 Can be one of:
 \itemize{
 \item "size": the total number of offspring.
-\item "length": the total number of ancestors.
+\item "length": the total number of infectors.
 }}
 
 \item{offspring_dist}{Offspring distribution: a character string
@@ -50,10 +50,8 @@ initial times. Defaults to 0.}
 }
 \value{
 An \verb{<epichains>} object, which is basically a \verb{<data.frame>} with
-columns \code{chain_id} (chain ID), \code{sim_id} (a unique ID within each simulation
-for each individual), \code{ancestor}
-(the ID of the ancestor of each individual), \code{generation}, and
-\code{time} (of infection)
+columns \code{infectee_id}, \code{sim_id} (a unique ID within each simulation
+for each infectee), \code{infector_id}, \code{generation}, and \code{time} (of infection)
 }
 \description{
 Simulate transmission trees from an initial number of infections

--- a/man/simulate_tree_from_pop.Rd
+++ b/man/simulate_tree_from_pop.Rd
@@ -39,9 +39,8 @@ Must be less than \code{pop} - 1.}
 }
 \value{
 An \verb{<epichains>} object, which is basically a \verb{<data.frame>} with
-columns \code{sim_id} (a unique ID within each simulation for each individual
-of the chain), \code{ancestor} (the ID of the ancestor of each individual),
-\code{generation}, and \code{time} (of infection).
+columns \code{sim_id} (a unique ID within each simulation for each infectee
+in the chain), \code{infector_id}, \code{generation}, and \code{time} (of infection).
 }
 \description{
 Simulate transmission trees from a susceptible or partially immune

--- a/man/tail.epichains.Rd
+++ b/man/tail.epichains.Rd
@@ -15,8 +15,8 @@
 \code{tail} method for \code{\link{epichains}} class
 }
 \details{
-This returns the top rows of an \code{epichains} object. Note that the object
-is originally sorted by \code{sim_id} and \code{ancestor} and the first
+This returns the bottom part of an \code{epichains} object. Note that the object
+is originally sorted by \code{sim_id} and \code{infector_id} and the first
 unknown ancestors (NA) have been dropped from
 printing method. To view the full output, use \verb{as.data.frame(<object_name>)}.
 }

--- a/tests/testthat/_snaps/epichains.md
+++ b/tests/testthat/_snaps/epichains.md
@@ -5,16 +5,16 @@
     Output
       `epichains` object
       
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
-      [1] sim_id     ancestor   generation time      
+      [1] sim_id      infector_id generation  time       
       <0 rows> (or 0-length row.names)
       
       < tree tail >
       
-        sim_id ancestor generation time
-      1      1       NA          1    0
-      Number of ancestors (known): 0
+      [1] sim_id      infector_id generation  time       
+      <0 rows> (or 0-length row.names)
+      Number of infectors (known): 0
       Number of generations: 1
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -25,7 +25,7 @@
     Output
       `epichains` object
       
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
         sim_id ancestor generation     time
       2      2        1          2 42.57973
@@ -55,7 +55,7 @@
     Output
       `epichains` object
       
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
          chain_id sim_id ancestor generation
       3         1      2        1          2
@@ -86,7 +86,7 @@
     Output
       `epichains` object
       
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
          chain_id sim_id ancestor generation time
       11        1      2        1          2    3
@@ -106,7 +106,7 @@
       105        4     22        9          4    9
       106        4     23        9          4    9
       Chains simulated: 10
-      Number of ancestors (known): 9
+      Number of infectors (known): 9
       Number of generations: 5
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -129,9 +129,9 @@
     Code
       head(susc_outbreak_raw)
     Output
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
-      [1] sim_id     ancestor   generation time      
+      [1] sim_id      infector_id generation  time       
       <0 rows> (or 0-length row.names)
 
 ---
@@ -139,7 +139,7 @@
     Code
       head(susc_outbreak_raw2)
     Output
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
         sim_id ancestor generation     time
       2      2        1          2 42.57973
@@ -154,7 +154,7 @@
     Code
       head(tree_sim_raw)
     Output
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
          chain_id sim_id ancestor generation
       3         1      2        1          2
@@ -169,7 +169,7 @@
     Code
       head(tree_sim_raw2)
     Output
-      < tree head (from first known ancestor) >
+      < tree head (from first known infector) >
       
          chain_id sim_id ancestor generation time
       11        1      2        1          2    3
@@ -187,8 +187,8 @@
       
       < tree tail >
       
-        sim_id ancestor generation time
-      1      1       NA          1    0
+      [1] sim_id      infector_id generation  time       
+      <0 rows> (or 0-length row.names)
 
 ---
 

--- a/tests/testthat/_snaps/epichains.md
+++ b/tests/testthat/_snaps/epichains.md
@@ -12,8 +12,8 @@
       
       < tree tail >
       
-      [1] sim_id      infector_id generation  time       
-      <0 rows> (or 0-length row.names)
+        sim_id infector_id generation time
+      1      1          NA          1    0
       Number of infectors (known): 0
       Number of generations: 1
       Use `as.data.frame(<object_name>)` to view the full output in the console.
@@ -27,24 +27,24 @@
       
       < tree head (from first known infector) >
       
-        sim_id ancestor generation     time
-      2      2        1          2 42.57973
-      3      3        2          3 42.80500
-      4      4        2          3 42.70415
-      5      5        4          4 43.87477
-      6      6        4          4 44.00812
-      7      7        3          4 78.73481
+        sim_id infector_id generation     time
+      2      2           1          2 42.57973
+      3      3           2          3 42.80500
+      4      4           2          3 42.70415
+      5      5           4          4 43.87477
+      6      6           4          4 44.00812
+      7      7           3          4 78.73481
       
       < tree tail >
       
-         sim_id ancestor generation     time
-      7       7        3          4 78.73481
-      8       8        5          5 47.03948
-      9       9        6          5 45.38534
-      10     10        9          6 46.14505
-      11     11        8          6 48.03103
-      12     12        7          5 81.49185
-      Number of ancestors (known): 9
+         sim_id infector_id generation     time
+      7       7           3          4 78.73481
+      8       8           5          5 47.03948
+      9       9           6          5 45.38534
+      10     10           9          6 46.14505
+      11     11           8          6 48.03103
+      12     12           7          5 81.49185
+      Number of infectors (known): 9
       Number of generations: 6
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -57,25 +57,25 @@
       
       < tree head (from first known infector) >
       
-         chain_id sim_id ancestor generation
-      3         1      2        1          2
-      6         2      2        1          2
-      4         1      3        1          2
-      7         2      3        1          2
-      5         1      4        1          2
-      11        2      4        2          3
+        infectee_id sim_id infector_id generation
+      3           1      2           1          2
+      4           2      2           1          2
+      5           1      3           1          2
+      6           2      3           1          2
+      7           1      4           1          2
+      8           2      4           2          3
       
       < tree tail >
       
-         chain_id sim_id ancestor generation
-      9         1      6        4          3
-      10        1      7        4          3
-      15        2      7        6          4
-      16        2      8        6          4
-      14        1      8        7          4
-      17        2      9        8          5
+         infectee_id sim_id infector_id generation
+      12           1      6           4          3
+      13           1      7           4          3
+      14           2      7           6          4
+      15           2      8           6          4
+      16           1      8           7          4
+      17           2      9           8          5
       Chains simulated: 2
-      Number of ancestors (known): 7
+      Number of infectors (known): 7
       Number of generations: 5
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -88,23 +88,23 @@
       
       < tree head (from first known infector) >
       
-         chain_id sim_id ancestor generation time
-      11        1      2        1          2    3
-      12        2      2        1          2    3
-      13        3      2        1          2    3
-      15        4      2        1          2    3
-      17        5      2        1          2    3
-      20        6      2        1          2    3
+         infectee_id sim_id infector_id generation time
+      11           1      2           1          2    3
+      12           2      2           1          2    3
+      13           3      2           1          2    3
+      14           4      2           1          2    3
+      15           5      2           1          2    3
+      16           6      2           1          2    3
       
       < tree tail >
       
-          chain_id sim_id ancestor generation time
-      131       10     19        9          4    9
-      81         2     20        6          4    9
-      103        4     20        9          4    9
-      104        4     21        9          4    9
-      105        4     22        9          4    9
-      106        4     23        9          4    9
+          infectee_id sim_id infector_id generation time
+      138          10     19           9          4    9
+      139           2     20           6          4    9
+      140           4     20           9          4    9
+      141           4     21           9          4    9
+      142           4     22           9          4    9
+      143           4     23           9          4    9
       Chains simulated: 10
       Number of infectors (known): 9
       Number of generations: 5
@@ -141,13 +141,13 @@
     Output
       < tree head (from first known infector) >
       
-        sim_id ancestor generation     time
-      2      2        1          2 42.57973
-      3      3        2          3 42.80500
-      4      4        2          3 42.70415
-      5      5        4          4 43.87477
-      6      6        4          4 44.00812
-      7      7        3          4 78.73481
+        sim_id infector_id generation     time
+      2      2           1          2 42.57973
+      3      3           2          3 42.80500
+      4      4           2          3 42.70415
+      5      5           4          4 43.87477
+      6      6           4          4 44.00812
+      7      7           3          4 78.73481
 
 ---
 
@@ -156,13 +156,13 @@
     Output
       < tree head (from first known infector) >
       
-         chain_id sim_id ancestor generation
-      3         1      2        1          2
-      6         2      2        1          2
-      4         1      3        1          2
-      7         2      3        1          2
-      5         1      4        1          2
-      11        2      4        2          3
+        infectee_id sim_id infector_id generation
+      3           1      2           1          2
+      4           2      2           1          2
+      5           1      3           1          2
+      6           2      3           1          2
+      7           1      4           1          2
+      8           2      4           2          3
 
 ---
 
@@ -171,13 +171,13 @@
     Output
       < tree head (from first known infector) >
       
-         chain_id sim_id ancestor generation time
-      11        1      2        1          2    3
-      12        2      2        1          2    3
-      13        3      2        1          2    3
-      15        4      2        1          2    3
-      17        5      2        1          2    3
-      20        6      2        1          2    3
+         infectee_id sim_id infector_id generation time
+      11           1      2           1          2    3
+      12           2      2           1          2    3
+      13           3      2           1          2    3
+      14           4      2           1          2    3
+      15           5      2           1          2    3
+      16           6      2           1          2    3
 
 ---
 
@@ -187,8 +187,8 @@
       
       < tree tail >
       
-      [1] sim_id      infector_id generation  time       
-      <0 rows> (or 0-length row.names)
+        sim_id infector_id generation time
+      1      1          NA          1    0
 
 ---
 
@@ -198,13 +198,13 @@
       
       < tree tail >
       
-         sim_id ancestor generation     time
-      7       7        3          4 78.73481
-      8       8        5          5 47.03948
-      9       9        6          5 45.38534
-      10     10        9          6 46.14505
-      11     11        8          6 48.03103
-      12     12        7          5 81.49185
+         sim_id infector_id generation     time
+      7       7           3          4 78.73481
+      8       8           5          5 47.03948
+      9       9           6          5 45.38534
+      10     10           9          6 46.14505
+      11     11           8          6 48.03103
+      12     12           7          5 81.49185
 
 ---
 
@@ -214,13 +214,13 @@
       
       < tree tail >
       
-         chain_id sim_id ancestor generation
-      9         1      6        4          3
-      10        1      7        4          3
-      15        2      7        6          4
-      16        2      8        6          4
-      14        1      8        7          4
-      17        2      9        8          5
+         infectee_id sim_id infector_id generation
+      12           1      6           4          3
+      13           1      7           4          3
+      14           2      7           6          4
+      15           2      8           6          4
+      16           1      8           7          4
+      17           2      9           8          5
 
 ---
 
@@ -230,11 +230,11 @@
       
       < tree tail >
       
-          chain_id sim_id ancestor generation time
-      131       10     19        9          4    9
-      81         2     20        6          4    9
-      103        4     20        9          4    9
-      104        4     21        9          4    9
-      105        4     22        9          4    9
-      106        4     23        9          4    9
+          infectee_id sim_id infector_id generation time
+      138          10     19           9          4    9
+      139           2     20           6          4    9
+      140           4     20           9          4    9
+      141           4     21           9          4    9
+      142           4     22           9          4    9
+      143           4     23           9          4    9
 

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -169,7 +169,7 @@ test_that("summary.epichains works as expected", {
     c(
       "chains_run",
       "max_time",
-      "unique_ancestors",
+      "unique_infectors",
       "max_generation"
     )
   )
@@ -178,7 +178,7 @@ test_that("summary.epichains works as expected", {
     c(
       "chains_run",
       "max_time",
-      "unique_ancestors",
+      "unique_infectors",
       "max_generation"
     )
   )
@@ -187,7 +187,7 @@ test_that("summary.epichains works as expected", {
     c(
       "chains_run",
       "max_time",
-      "unique_ancestors",
+      "unique_infectors",
       "max_generation"
     )
   )
@@ -196,7 +196,7 @@ test_that("summary.epichains works as expected", {
     c(
       "chains_run",
       "max_time",
-      "unique_ancestors",
+      "unique_infectors",
       "max_generation"
     )
   )

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -239,7 +239,7 @@ test_that("simulate_tree is numerically correct", {
     2.00
   )
   expect_identical(
-    tree_sim_summary$unique_ancestors,
+    tree_sim_summary$unique_infectors,
     2L
   )
   expect_identical(
@@ -247,7 +247,7 @@ test_that("simulate_tree is numerically correct", {
     3L
   )
   expect_identical(
-    tree_sim_raw$chain_id,
+    tree_sim_raw$infectee_id,
     c(1L, 2L, 2L, 2L, 2L, 2L, 2L)
   )
   expect_identical(
@@ -255,7 +255,7 @@ test_that("simulate_tree is numerically correct", {
     c(1, 1, 2, 3, 4, 5, 6)
   )
   expect_identical(
-    tree_sim_raw$ancestor,
+    tree_sim_raw$infector_id,
     c(NA, NA, 1, 1, 2, 2, 2)
   )
   expect_identical(
@@ -268,7 +268,7 @@ test_that("simulate_tree is numerically correct", {
     2.0
   )
   expect_identical(
-    tree_sim_summary$unique_ancestors,
+    tree_sim_summary$unique_infectors,
     2L
   )
   expect_identical(
@@ -276,7 +276,7 @@ test_that("simulate_tree is numerically correct", {
     3L
   )
   expect_identical(
-    tree_sim_raw$chain_id,
+    tree_sim_raw$infectee_id,
     c(1L, 2L, 2L, 2L, 2L, 2L, 2L)
   )
   expect_identical(
@@ -284,7 +284,7 @@ test_that("simulate_tree is numerically correct", {
     c(1, 1, 2, 3, 4, 5, 6)
   )
   expect_identical(
-    tree_sim_raw$ancestor,
+    tree_sim_raw$infector_id,
     c(NA, NA, 1, 1, 2, 2, 2)
   )
   expect_identical(
@@ -336,7 +336,7 @@ test_that("simulate_tree_from_pop is numerically correct", {
   susc_outbreak_summary <- summary(susc_outbreak_raw)
   #' Expectations
   expect_identical(
-    susc_outbreak_summary$unique_ancestors,
+    susc_outbreak_summary$unique_infectors,
     0L
   )
   expect_identical(
@@ -353,7 +353,7 @@ test_that("simulate_tree_from_pop is numerically correct", {
     1L
   )
   expect_identical(
-    susc_outbreak_raw$ancestor,
+    susc_outbreak_raw$infector_id,
     NA_integer_
   )
   expect_identical(


### PR DESCRIPTION
This PR:

- Renames the `ancestor` and `chain_id` columns of the `<epichains>` object to `infector_id` and `infectee_id`. This closes #92 
- Removes rownames from the `<epichains>` object to close #93. 