### PR TITLE
Remove defaults from class constructors and validators

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -17,11 +17,11 @@
 #' @author James M. Azam
 #' @keywords internal
 new_epichains_tree <- function(tree_df,
-                               ntrees = integer(),
-                               statistic = character(),
-                               offspring_dist = character(),
-                               stat_max = integer(),
-                               track_pop = logical()) {
+                               ntrees,
+                               statistic,
+                               offspring_dist,
+                               stat_max,
+                               track_pop) {
   # Assemble the elements of the object
   obj <- structure(
     tree_df,
@@ -58,11 +58,11 @@ new_epichains_tree <- function(tree_df,
 #' @author James M. Azam
 #' @export
 epichains_tree <- function(tree_df,
-                           ntrees = integer(),
-                           statistic = character(),
-                           offspring_dist = character(),
-                           stat_max = integer(),
-                           track_pop = logical()) {
+                           ntrees,
+                           statistic,
+                           offspring_dist,
+                           stat_max,
+                           track_pop) {
   # Check that inputs are well specified
   checkmate::assert_data_frame(tree_df)
   checkmate::assert_integerish(ntrees, null.ok = TRUE)
@@ -107,10 +107,10 @@ epichains_tree <- function(tree_df,
 #' @author James M. Azam
 #' @keywords internal
 new_epichains_summary <- function(chains_summary,
-                                  ntrees = integer(),
-                                  statistic = character(),
-                                  offspring_dist = character(),
-                                  stat_max = integer()) {
+                                  ntrees,
+                                  statistic,
+                                  offspring_dist,
+                                  stat_max) {
   # Assemble the elements of the object
   obj <- structure(
     chains_summary,
@@ -139,10 +139,10 @@ new_epichains_summary <- function(chains_summary,
 #' @author James M. Azam
 #' @export
 epichains_summary <- function(chains_summary,
-                              ntrees = integer(),
-                              statistic = character(),
-                              offspring_dist = character(),
-                              stat_max = integer()) {
+                              ntrees,
+                              statistic,
+                              offspring_dist,
+                              stat_max) {
   # Check that inputs are well specified
   checkmate::assert_vector(chains_summary)
   checkmate::assert_integerish(ntrees, null.ok = TRUE)

--- a/man/epichains_summary.Rd
+++ b/man/epichains_summary.Rd
@@ -4,13 +4,7 @@
 \alias{epichains_summary}
 \title{Create an \verb{<epichains_summary>} object}
 \usage{
-epichains_summary(
-  chains_summary,
-  ntrees = integer(),
-  statistic = character(),
-  offspring_dist = character(),
-  stat_max = integer()
-)
+epichains_summary(chains_summary, ntrees, statistic, offspring_dist, stat_max)
 }
 \arguments{
 \item{chains_summary}{a \verb{<vector>} of chain sizes and lengths.}

--- a/man/epichains_tree.Rd
+++ b/man/epichains_tree.Rd
@@ -4,14 +4,7 @@
 \alias{epichains_tree}
 \title{Create an \verb{<epichains_tree>} object}
 \usage{
-epichains_tree(
-  tree_df,
-  ntrees = integer(),
-  statistic = character(),
-  offspring_dist = character(),
-  stat_max = integer(),
-  track_pop = logical()
-)
+epichains_tree(tree_df, ntrees, statistic, offspring_dist, stat_max, track_pop)
 }
 \arguments{
 \item{tree_df}{a \verb{<data.frame>} containing at least columns for

--- a/man/new_epichains_summary.Rd
+++ b/man/new_epichains_summary.Rd
@@ -6,10 +6,10 @@
 \usage{
 new_epichains_summary(
   chains_summary,
-  ntrees = integer(),
-  statistic = character(),
-  offspring_dist = character(),
-  stat_max = integer()
+  ntrees,
+  statistic,
+  offspring_dist,
+  stat_max
 )
 }
 \arguments{

--- a/man/new_epichains_tree.Rd
+++ b/man/new_epichains_tree.Rd
@@ -6,11 +6,11 @@
 \usage{
 new_epichains_tree(
   tree_df,
-  ntrees = integer(),
-  statistic = character(),
-  offspring_dist = character(),
-  stat_max = integer(),
-  track_pop = logical()
+  ntrees,
+  statistic,
+  offspring_dist,
+  stat_max,
+  track_pop
 )
 }
 \arguments{


### PR DESCRIPTION
This PR closes #161 by removing the empty defaults that were passed to the constructor and validation functions of `<epichains_tree>` and `<epichains_summary>` objects.
