### PR TITLE
Add lint-changed-files and dependency-change workflows

### DIFF
--- a/.github/workflows/dependency-change.yaml
+++ b/.github/workflows/dependency-change.yaml
@@ -1,0 +1,75 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  pull_request:
+    paths:
+      - 'DESCRIPTION'
+
+name: Analyze dependency changes
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependency-changes:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: any::pak, glue, gh
+
+      - name: Analyze dependency changes
+        shell: Rscript {0}
+        run: |
+          deps_base <- pak::pkg_deps("${{ github.repository }}@${{ github.base_ref }}", dependencies = TRUE) |>
+            subset(!directpkg) |>
+            subset(is.na(priority))
+          # We install from PR number rather than branch to deal with the case
+          # of PR coming from forks
+          deps_head <- pak::pkg_deps("${{ github.repository }}#${{ github.event.number }}", dependencies = TRUE) |>
+            subset(!directpkg) |>
+            subset(is.na(priority))
+
+          deps_added <- deps_head |>
+            subset(!ref %in% deps_base$ref)
+
+          deps_removed <- deps_base |>
+            subset(!ref %in% deps_head$ref)
+
+          if (nrow(deps_added) + nrow(deps_removed) > 0) {
+
+            message("Dependencies have changed! Analyzing...")
+
+            msg <- glue::glue(
+              .sep = "\n",
+              "This pull request:",
+              "- Adds {nrow(deps_added)} new dependencies (direct and indirect)",
+              "- Adds {length(unique(deps_added$sysreqs))} new system dependencies",
+              "- Removes {nrow(deps_removed)} existing dependencies (direct and indirect)",
+              "- Removes {length(unique(deps_removed$sysreqs))} existing system dependencies",
+              "",
+              "(Note that results may be inacurrate if you branched from an outdated version of the target branch.)"
+            )
+
+            message("Posting results as a pull request comment.")
+
+            gh::gh(
+              "POST /repos/{repo}/issues/{issue_number}/comments",
+              repo = "${{ github.repository }}",
+              issue_number = "${{ github.event.number }}",
+              body = msg
+            )
+
+          }

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,47 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, master]
+
+name: lint-changed-files
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::gh
+            any::lintr
+            any::purrr
+            epiverse-trace/etdev
+          needs: check
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true


### PR DESCRIPTION
This PR:
- Re-adds `lint-changed-files` workflow to be run at the package level because of some changes to GitHub policies that prevent us from using organization-wide workflows
- Adds the `dependency-change` workflow to check for changes in dependencies in PRs.
