### PR TITLE
Add .lintr configuration from packagetemplate

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,16 +1,39 @@
-linters: linters_with_tags(
-    tags = NULL, # include all linters
+linters: all_linters(
+    packages = c("lintr", "etdev"),
     object_name_linter = NULL,
-    undesirable_function_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    library_call_linter = NULL,
+    undesirable_function_linter(
+      modify_defaults(
+        default_undesirable_functions,
+        citEntry = "use the more modern bibentry() function",
+        library = NULL # too many false positive in too many files
+      )
+    ),
     function_argument_linter = NULL,
     cyclocomp_linter(25L),
+    indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())
   )
 exclusions: list(
-    "tests/testthat.R" = list(unused_import_linter = Inf)
+    "tests/testthat.R" = list(
+      unused_import_linter = Inf
+    ),
+    "tests" = list(
+      undesirable_function_linter = Inf
+    ),
+    "data-raw" = list(
+      missing_package_linter = Inf,
+      namespace_linter = Inf
+    ),
+    # RcppExports.R is auto-generated and will not pass many linters. In
+    # particular, it can create very long lines.
+    "R/RcppExports.R",
+    # R/stanmodels.R is auto-generated and will not pass many linters. In
+    # particular, it uses `sapply()`.
+    "R/stanmodels.R"
   )


### PR DESCRIPTION
This PR closes #177 by updating the current `.lintr` file to use the configuration provided in the Epiverse-TRACE [`{packagetemplate}`](https://github.com/epiverse-trace/packagetemplate).
