### PR TITLE
Rename `ntrees` argument to `index_cases` to clarify meaning

### DIFF
--- a/R/borel.r
+++ b/R/borel.r
@@ -38,7 +38,7 @@ rborel <- function(n, mu, infinite = Inf) {
   )
   # Run simulations
   out <- simulate_summary(
-    ntrees = n,
+    index_cases = n,
     offspring_dist = "pois",
     statistic = "size",
     stat_max = infinite,

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -11,13 +11,12 @@
 #' @param tree_df a `<data.frame>` containing at least columns for
 #' "infectee_id", "infector_id", and "generation". Also has optional columns
 #' for "time", and "chain_id".
-#' @param ntrees Number of initial cases used to generate the outbreak; Integer
 #' @param track_pop Was the susceptible population tracked? Logical
 #' @inheritParams epichains_tree
 #' @author James M. Azam
 #' @keywords internal
 new_epichains_tree <- function(tree_df,
-                               ntrees,
+                               index_cases,
                                statistic,
                                offspring_dist,
                                stat_max,
@@ -25,7 +24,7 @@ new_epichains_tree <- function(tree_df,
   # Assemble the elements of the object
   obj <- tree_df
   class(obj) <- c("epichains_tree", class(obj))
-  attr(obj, "ntrees") <- ntrees
+  attr(obj, "index_cases") <- index_cases
   attr(obj, "statistic") <- statistic
   attr(obj, "offspring_dist") <- offspring_dist
   attr(obj, "stat_max") <- stat_max
@@ -56,14 +55,14 @@ new_epichains_tree <- function(tree_df,
 #' @author James M. Azam
 #' @export
 epichains_tree <- function(tree_df,
-                           ntrees,
+                           index_cases,
                            statistic,
                            offspring_dist,
                            stat_max,
                            track_pop) {
   # Check that inputs are well specified
   checkmate::assert_data_frame(tree_df)
-  checkmate::assert_integerish(ntrees, null.ok = TRUE)
+  checkmate::assert_integerish(index_cases, null.ok = TRUE)
   checkmate::assert_character(statistic, null.ok = TRUE)
   checkmate::assert_string(offspring_dist)
   check_offspring_func_valid(paste0("r", offspring_dist))
@@ -73,7 +72,7 @@ epichains_tree <- function(tree_df,
   # Create <epichains_tree> object
   epichains_tree <- new_epichains_tree(
     tree_df = tree_df,
-    ntrees = ntrees,
+    index_cases = index_cases,
     statistic = statistic,
     offspring_dist = offspring_dist,
     stat_max = stat_max,
@@ -105,14 +104,14 @@ epichains_tree <- function(tree_df,
 #' @author James M. Azam
 #' @keywords internal
 new_epichains_summary <- function(chains_summary,
-                                  ntrees,
+                                  index_cases,
                                   statistic,
                                   offspring_dist,
                                   stat_max) {
   # Assemble the elements of the object
   obj <- chains_summary
   class(obj) <- c("epichains_summary", class(chains_summary))
-  attr(obj, "ntrees") <- ntrees
+  attr(obj, "index_cases") <- index_cases
   attr(obj, "statistic") <- statistic
   attr(obj, "offspring_dist") <- offspring_dist
   attr(obj, "stat_max") <- stat_max
@@ -135,13 +134,13 @@ new_epichains_summary <- function(chains_summary,
 #' @author James M. Azam
 #' @export
 epichains_summary <- function(chains_summary,
-                              ntrees,
+                              index_cases,
                               statistic,
                               offspring_dist,
                               stat_max) {
   # Check that inputs are well specified
   checkmate::assert_vector(chains_summary)
-  checkmate::assert_integerish(ntrees, null.ok = TRUE)
+  checkmate::assert_integerish(index_cases, null.ok = TRUE)
   checkmate::assert_character(statistic)
   checkmate::assert_string(offspring_dist)
   check_offspring_func_valid(paste0("r", offspring_dist))
@@ -150,7 +149,7 @@ epichains_summary <- function(chains_summary,
   # Create <epichains_summary> object
   epichains_summary <- new_epichains_summary(
     chains_summary,
-    ntrees = ntrees,
+    index_cases = index_cases,
     statistic = statistic,
     offspring_dist = offspring_dist,
     stat_max = stat_max
@@ -216,7 +215,7 @@ format.epichains_tree <- function(x, ...) {
       ),
       sprintf(
         "Trees simulated: %s",
-        tree_info[["ntrees"]]
+        tree_info[["index_cases"]]
       ),
       sprintf(
         "Number of infectors (known): %s",
@@ -295,7 +294,7 @@ summary.epichains_tree <- function(object, ...) {
   validate_epichains_tree(object)
 
   # Get the summaries
-  ntrees <- attr(object, "ntrees", exact = TRUE)
+  index_cases <- attr(object, "index_cases", exact = TRUE)
 
   max_time <- ifelse(("time" %in% names(object)), max(object$time), NA)
 
@@ -307,7 +306,7 @@ summary.epichains_tree <- function(object, ...) {
 
   # List of summaries
   out <- list(
-    ntrees = ntrees,
+    index_cases = index_cases,
     max_time = max_time,
     unique_infectors = n_unique_infectors,
     max_generation = max_generation
@@ -329,7 +328,7 @@ summary.epichains_summary <- function(object, ...) {
   validate_epichains_summary(object)
 
   # Get the summaries
-  ntrees <- attr(object, "ntrees", exact = TRUE)
+  index_cases <- attr(object, "index_cases", exact = TRUE)
 
 
   if (all(is.infinite(object))) {
@@ -340,7 +339,7 @@ summary.epichains_summary <- function(object, ...) {
   }
 
   out <- list(
-    ntrees = ntrees,
+    index_cases = index_cases,
     max_stat = max_stat,
     min_stat = min_stat
   )

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -371,7 +371,7 @@ simulate_summary <- function(index_cases, statistic = c("size", "length"),
   pars <- list(...)
 
   # Initialisations
-  stat_track <- rep(1, index_cases) ## track length or size (depending on `stat`)
+  stat_track <- rep(1, index_cases) ## track statistic
   n_offspring <- rep(1, index_cases) ## current number of offspring
   sim <- seq_len(index_cases) ## track trees that are still being simulated
 

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -320,7 +320,7 @@ simulate_chains <- function(index_cases,
   rownames(tree_df) <- NULL
   out <- epichains_tree(
     tree_df,
-    ntrees = index_cases,
+    index_cases = index_cases,
     statistic = statistic,
     offspring_dist = offspring_dist,
     stat_max = stat_max,
@@ -332,25 +332,24 @@ simulate_chains <- function(index_cases,
 #' Simulate transmission chains sizes/lengths
 #'
 #' @inheritParams simulate_chains
-#' @param ntrees Number of trees to simulate.
 #' @param stat_max A cut off for the chain statistic (size/length) being
 #' computed. Results above the specified value, are set to `Inf`.
 #' @inheritSection simulate_chains Calculating chain sizes and lengths
 #' @author James M. Azam, Sebastian Funk
 #' @examples
 #' simulate_summary(
-#'   ntrees = 10,
+#'   index_cases = 10,
 #'   statistic = "size",
 #'   offspring_dist = "pois",
 #'   stat_max = 10,
 #'   lambda = 2
 #' )
 #' @export
-simulate_summary <- function(ntrees, statistic = c("size", "length"),
+simulate_summary <- function(index_cases, statistic = c("size", "length"),
                              offspring_dist,
                              stat_max = Inf, ...) {
   # Input checking
-  checkmate::assert_count(ntrees, positive = TRUE)
+  checkmate::assert_count(index_cases, positive = TRUE)
   statistic <- match.arg(statistic)
   checkmate::assert_choice(
     statistic,
@@ -372,11 +371,11 @@ simulate_summary <- function(ntrees, statistic = c("size", "length"),
   pars <- list(...)
 
   # Initialisations
-  stat_track <- rep(1, ntrees) ## track length or size (depending on `stat`)
-  n_offspring <- rep(1, ntrees) ## current number of offspring
-  sim <- seq_len(ntrees) ## track trees that are still being simulated
+  stat_track <- rep(1, index_cases) ## track length or size (depending on `stat`)
+  n_offspring <- rep(1, index_cases) ## current number of offspring
+  sim <- seq_len(index_cases) ## track trees that are still being simulated
 
-  ## next, simulate ntrees trees
+  ## next, simulate trees from index cases
   while (length(sim) > 0) {
     ## simulate next generation
     next_gen <- do.call(
@@ -394,7 +393,7 @@ simulate_summary <- function(ntrees, statistic = c("size", "length"),
     indices <- rep(sim, n_offspring[sim])
 
     ## initialise number of offspring
-    n_offspring <- rep(0, ntrees)
+    n_offspring <- rep(0, index_cases)
     ## assign offspring sum to indices still being simulated
     n_offspring[sim] <- tapply(next_gen, indices, sum)
 
@@ -414,7 +413,7 @@ simulate_summary <- function(ntrees, statistic = c("size", "length"),
 
   out <- epichains_summary(
     chains_summary = stat_track,
-    ntrees = ntrees,
+    index_cases = index_cases,
     statistic = statistic,
     offspring_dist = offspring_dist,
     stat_max = stat_max

--- a/R/stat_likelihoods.R
+++ b/R/stat_likelihoods.R
@@ -186,7 +186,7 @@ offspring_ll <- function(x, offspring_dist, statistic,
 
   # Simulate the chains
   dist <- simulate_summary(
-    ntrees = nsim_offspring,
+    index_cases = nsim_offspring,
     offspring_dist = offspring_dist,
     statistic = statistic,
     ...

--- a/man/epichains_summary.Rd
+++ b/man/epichains_summary.Rd
@@ -4,12 +4,18 @@
 \alias{epichains_summary}
 \title{Create an \verb{<epichains_summary>} object}
 \usage{
-epichains_summary(chains_summary, ntrees, statistic, offspring_dist, stat_max)
+epichains_summary(
+  chains_summary,
+  index_cases,
+  statistic,
+  offspring_dist,
+  stat_max
+)
 }
 \arguments{
 \item{chains_summary}{a \verb{<vector>} of chain sizes and lengths.}
 
-\item{ntrees}{Number of initial cases used to generate the outbreak; Integer}
+\item{index_cases}{Number of index cases to simulate transmission chains for.}
 
 \item{statistic}{\verb{<String>}; Chain statistic to track as the stopping
 criteria for each chain being simulated when \code{stat_max} is not \code{Inf}.

--- a/man/epichains_tree.Rd
+++ b/man/epichains_tree.Rd
@@ -4,14 +4,21 @@
 \alias{epichains_tree}
 \title{Create an \verb{<epichains_tree>} object}
 \usage{
-epichains_tree(tree_df, ntrees, statistic, offspring_dist, stat_max, track_pop)
+epichains_tree(
+  tree_df,
+  index_cases,
+  statistic,
+  offspring_dist,
+  stat_max,
+  track_pop
+)
 }
 \arguments{
 \item{tree_df}{a \verb{<data.frame>} containing at least columns for
 "infectee_id", "infector_id", and "generation". Also has optional columns
 for "time", and "chain_id".}
 
-\item{ntrees}{Number of initial cases used to generate the outbreak; Integer}
+\item{index_cases}{Number of index cases to simulate transmission chains for.}
 
 \item{statistic}{\verb{<String>}; Chain statistic to track as the stopping
 criteria for each chain being simulated when \code{stat_max} is not \code{Inf}.

--- a/man/new_epichains_summary.Rd
+++ b/man/new_epichains_summary.Rd
@@ -6,7 +6,7 @@
 \usage{
 new_epichains_summary(
   chains_summary,
-  ntrees,
+  index_cases,
   statistic,
   offspring_dist,
   stat_max
@@ -15,7 +15,7 @@ new_epichains_summary(
 \arguments{
 \item{chains_summary}{a \verb{<vector>} of chain sizes and lengths.}
 
-\item{ntrees}{Number of initial cases used to generate the outbreak; Integer}
+\item{index_cases}{Number of index cases to simulate transmission chains for.}
 
 \item{statistic}{\verb{<String>}; Chain statistic to track as the stopping
 criteria for each chain being simulated when \code{stat_max} is not \code{Inf}.

--- a/man/new_epichains_tree.Rd
+++ b/man/new_epichains_tree.Rd
@@ -6,7 +6,7 @@
 \usage{
 new_epichains_tree(
   tree_df,
-  ntrees,
+  index_cases,
   statistic,
   offspring_dist,
   stat_max,
@@ -18,7 +18,7 @@ new_epichains_tree(
 "infectee_id", "infector_id", and "generation". Also has optional columns
 for "time", and "chain_id".}
 
-\item{ntrees}{Number of initial cases used to generate the outbreak; Integer}
+\item{index_cases}{Number of index cases to simulate transmission chains for.}
 
 \item{statistic}{\verb{<String>}; Chain statistic to track as the stopping
 criteria for each chain being simulated when \code{stat_max} is not \code{Inf}.

--- a/man/simulate_summary.Rd
+++ b/man/simulate_summary.Rd
@@ -5,7 +5,7 @@
 \title{Simulate transmission chains sizes/lengths}
 \usage{
 simulate_summary(
-  ntrees,
+  index_cases,
   statistic = c("size", "length"),
   offspring_dist,
   stat_max = Inf,
@@ -13,7 +13,7 @@ simulate_summary(
 )
 }
 \arguments{
-\item{ntrees}{Number of trees to simulate.}
+\item{index_cases}{Number of index cases to simulate transmission chains for.}
 
 \item{statistic}{\verb{<String>}; Chain statistic to track as the stopping
 criteria for each chain being simulated when \code{stat_max} is not \code{Inf}.
@@ -76,7 +76,7 @@ where \code{...} are the other arguments to \verb{simulate_*()}.
 
 \examples{
 simulate_summary(
-  ntrees = 10,
+  index_cases = 10,
   statistic = "size",
   offspring_dist = "pois",
   stat_max = 10,

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -44,7 +44,7 @@ test_that("Simulators return epichains objects", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -111,7 +111,7 @@ test_that("print.epichains_tree works for simulation functions", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -163,7 +163,7 @@ test_that("summary.epichains_tree works as expected", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -171,7 +171,7 @@ test_that("summary.epichains_tree works as expected", {
   #' Simulate case where all the chain statistics are Inf
   set.seed(11223)
   epichains_summary_all_infs <- simulate_summary(
-    ntrees = 10,
+    index_cases = 10,
     statistic = "size",
     offspring_dist = "pois",
     stat_max = 10,
@@ -181,7 +181,7 @@ test_that("summary.epichains_tree works as expected", {
   expect_named(
     summary(tree_sim_raw),
     c(
-      "ntrees",
+      "index_cases",
       "max_time",
       "unique_infectors",
       "max_generation"
@@ -190,7 +190,7 @@ test_that("summary.epichains_tree works as expected", {
   expect_named(
     summary(tree_sim_raw2),
     c(
-      "ntrees",
+      "index_cases",
       "max_time",
       "unique_infectors",
       "max_generation"
@@ -199,7 +199,7 @@ test_that("summary.epichains_tree works as expected", {
   expect_named(
     summary(susc_outbreak_raw),
     c(
-      "ntrees",
+      "index_cases",
       "max_time",
       "unique_infectors",
       "max_generation"
@@ -208,7 +208,7 @@ test_that("summary.epichains_tree works as expected", {
   expect_named(
     summary(susc_outbreak_raw2),
     c(
-      "ntrees",
+      "index_cases",
       "max_time",
       "unique_infectors",
       "max_generation"
@@ -217,7 +217,7 @@ test_that("summary.epichains_tree works as expected", {
   expect_named(
     summary(chain_summary_raw),
     c(
-      "ntrees",
+      "index_cases",
       "max_stat",
       "min_stat"
     )
@@ -273,7 +273,7 @@ test_that("validate_epichains_tree works", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -335,7 +335,7 @@ test_that("is_chains_tree works", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -397,7 +397,7 @@ test_that("is_chains_summary works", {
   )
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -7,7 +7,7 @@ test_that("simulate_summary has expected shape", {
   set.seed(12)
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -228,7 +228,7 @@ test_that("simulate_chains throws errors", {
 test_that("simulate_summary throws errors", {
   expect_error(
     simulate_summary(
-      ntrees = 2,
+      index_cases = 2,
       offspring_dist = "s",
       statistic = "length",
       lambda = 0.9
@@ -237,7 +237,7 @@ test_that("simulate_summary throws errors", {
   )
   expect_error(
     simulate_summary(
-      ntrees = 2,
+      index_cases = 2,
       offspring_dist = "lnorm",
       statistic = "length",
       meanlog = 0.9,
@@ -247,7 +247,7 @@ test_that("simulate_summary throws errors", {
   )
   expect_error(
     simulate_summary(
-      ntrees = 2,
+      index_cases = 2,
       offspring_dist = s,
       statistic = "length",
       meanlog = 0.9,
@@ -257,7 +257,7 @@ test_that("simulate_summary throws errors", {
   )
   expect_error(
     simulate_summary(
-      ntrees = 2,
+      index_cases = 2,
       offspring_dist = c(1, 2),
       statistic = "length",
       lambda = 0.9
@@ -281,7 +281,7 @@ test_that("simulate_chains is numerically correct", {
   sim_chains_summary <- summary(sim_chains_small_susc)
   #' Expectations
   expect_identical(
-    sim_chains_summary$ntrees,
+    sim_chains_summary$index_cases,
     10.00
   )
   expect_identical(
@@ -340,7 +340,7 @@ test_that("simulate_summary is numerically correct", {
   set.seed(12)
   #' Simulate chain statistics
   chain_summary_raw <- simulate_summary(
-    ntrees = 2,
+    index_cases = 2,
     offspring_dist = "pois",
     statistic = "length",
     lambda = 0.9
@@ -349,7 +349,7 @@ test_that("simulate_summary is numerically correct", {
   chain_summary_summaries <- summary(chain_summary_raw)
   #' Expectations
   expect_identical(
-    chain_summary_summaries$ntrees,
+    chain_summary_summaries$index_cases,
     2.00
   )
   expect_identical(

--- a/vignettes/epichains.Rmd
+++ b/vignettes/epichains.Rmd
@@ -263,7 +263,7 @@ distribution with mean of $0.9$.
 set.seed(123)
 
 simulate_summary_eg <- simulate_summary(
-  ntrees = 10,
+  index_cases = 10,
   statistic = "size",
   offspring_dist = "pois",
   stat_max = 10,
@@ -302,7 +302,7 @@ summary(sim_chains)
 set.seed(123)
 
 simulate_summary_eg <- simulate_summary(
-  ntrees = 10,
+  index_cases = 10,
   statistic = "size",
   offspring_dist = "pois",
   stat_max = 10,

--- a/vignettes/interventions.Rmd
+++ b/vignettes/interventions.Rmd
@@ -45,7 +45,8 @@ We simulate 200 chains tracking up to 99 infections:
 
 ```{r simulate_chains}
 sims <- simulate_summary(
-  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 1.2, size = 0.5
+  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 1.2,
+  size = 0.5
 )
 ```
 
@@ -70,7 +71,8 @@ For example, to reduce R by 25% at the population level we scale the `mu` parame
 
 ```{r simulate_chains_pop_control}
 sims <- simulate_summary(
-  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 0.9, size = 0.5
+  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 0.9,
+  size = 0.5
 )
 sims[is.infinite(sims)] <- 100 # Replace infections > 99 with 100 for plotting.
 ggplot(data.frame(x = sims), aes(x = x)) +
@@ -137,8 +139,8 @@ This can be likened to a disease control strategy where gatherings are limited t
 
 ```{r simulate_chains_truncated}
 sims <- simulate_summary(
-  index_cases = 200, offspring_dist = "nbinom_truncated", stat_max = 99, mu = 1.2,
-  size = 0.5, max =  10
+  index_cases = 200, offspring_dist = "nbinom_truncated", stat_max = 99,
+  mu = 1.2, size = 0.5, max =  10
 )
 sims[is.infinite(sims)] <- 100 # Replace infections > 99 with 100 for plotting.
 ggplot(data.frame(x = sims), aes(x = x)) +

--- a/vignettes/interventions.Rmd
+++ b/vignettes/interventions.Rmd
@@ -45,7 +45,7 @@ We simulate 200 chains tracking up to 99 infections:
 
 ```{r simulate_chains}
 sims <- simulate_summary(
-  ntrees = 200, offspring_dist = "nbinom", stat_max = 99, mu = 1.2, size = 0.5
+  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 1.2, size = 0.5
 )
 ```
 
@@ -70,7 +70,7 @@ For example, to reduce R by 25% at the population level we scale the `mu` parame
 
 ```{r simulate_chains_pop_control}
 sims <- simulate_summary(
-  ntrees = 200, offspring_dist = "nbinom", stat_max = 99, mu = 0.9, size = 0.5
+  index_cases = 200, offspring_dist = "nbinom", stat_max = 99, mu = 0.9, size = 0.5
 )
 sims[is.infinite(sims)] <- 100 # Replace infections > 99 with 100 for plotting.
 ggplot(data.frame(x = sims), aes(x = x)) +
@@ -107,7 +107,7 @@ Having defined this, we can generate simulations as before:
 
 ```{r simulate_chains_ind_control}
 sims <- simulate_summary(
-  ntrees = 200, offspring_dist = "nbinom_ind", stat_max = 99, mu = 1.2,
+  index_cases = 200, offspring_dist = "nbinom_ind", stat_max = 99, mu = 1.2,
   size = 0.5, control = 0.25
 )
 sims[is.infinite(sims)] <- 100 # Replace infections > 99 with 100 for plotting.
@@ -137,7 +137,7 @@ This can be likened to a disease control strategy where gatherings are limited t
 
 ```{r simulate_chains_truncated}
 sims <- simulate_summary(
-  ntrees = 200, offspring_dist = "nbinom_truncated", stat_max = 99, mu = 1.2,
+  index_cases = 200, offspring_dist = "nbinom_truncated", stat_max = 99, mu = 1.2,
   size = 0.5, max =  10
 )
 sims[is.infinite(sims)] <- 100 # Replace infections > 99 with 100 for plotting.


### PR DESCRIPTION
This PR renames the `ntrees` argument to `index_cases` to help clarify the review comment in #158. The PR closes #158 and closes #186.
