### PR TITLE
Restore cyclocomp_linter defaults

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -13,7 +13,6 @@ linters: all_linters(
       )
     ),
     function_argument_linter = NULL,
-    cyclocomp_linter(25L),
     indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -124,6 +124,7 @@
 #' "Branching Process Models for Surveillance of Infectious Diseases
 #' Controlled by Mass Vaccination.” Biostatistics (Oxford, England)
 #' 4 (2): 279–95. \doi{https://doi.org/10.1093/biostatistics/4.2.279}.
+# nolint start: cyclocomp_linter
 simulate_chains <- function(index_cases,
                             statistic = c("size", "length"),
                             offspring_dist,
@@ -328,6 +329,7 @@ simulate_chains <- function(index_cases,
   )
   return(out)
 }
+# nolint end
 
 #' Simulate transmission chains sizes/lengths
 #'

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -124,7 +124,7 @@
 #' "Branching Process Models for Surveillance of Infectious Diseases
 #' Controlled by Mass Vaccination.” Biostatistics (Oxford, England)
 #' 4 (2): 279–95. \doi{https://doi.org/10.1093/biostatistics/4.2.279}.
-# nolint start: cyclocomp_linter
+# nolint start: cyclocomp_linter.
 simulate_chains <- function(index_cases,
                             statistic = c("size", "length"),
                             offspring_dist,


### PR DESCRIPTION
This PR closes #196 and fixes #179 by restoring the cyclocomp_linter default limit of 15L and excluding `simulate_chains()` from the `cyclocomp_linter` run.

Further revisions in #194 will reduce the cyclomatic complexity as far as possible. 