### PR TITLE
Make `switch()` statements error when there's no match

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -10,7 +10,8 @@
     switch(
       stat_type,
       size = stat_latest + n_offspring,
-      length = stat_latest + pmin(1, n_offspring)
+      length = stat_latest + pmin(1, n_offspring),
+      stop("stat_type must be 'size' or 'length'")
     )
   )
 }
@@ -26,7 +27,8 @@
     switch(
       chain_statistic,
       size = rbinom_size,
-      length = rgen_length
+      length = rgen_length,
+      stop("chain_statistic must be 'size' or 'length'")
     )
   )
 }

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -17,6 +17,14 @@ test_that("update_chain_stat works correctly", {
     ),
     stat_latest + pmin(1, n_offspring)
   )
+  expect_error(
+    .update_chain_stat(
+      stat_type = "foo",
+      stat_latest = stat_latest,
+      n_offspring = n_offspring
+    ),
+    "stat_type must be 'size' or 'length'"
+  )
 })
 
 test_that("get_statistic_func works correctly", {
@@ -27,5 +35,9 @@ test_that("get_statistic_func works correctly", {
   expect_identical(
     .get_statistic_func(chain_statistic = "length"),
     rgen_length
+  )
+  expect_error(
+    .get_statistic_func(chain_statistic = "foo"),
+    "chain_statistic must be 'size' or 'length'"
   )
 })


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING guidelines 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A failsafe to prevent bugs.


* **What is the current behaviour?** (You can also link to an open issue here)

The helper functions `.update_chain_stat()` and `.get_statistic_func()` used `switch()` statements that
did not error if there was no match. In fact, `switch()` statements return NULL if there is no match, which could potentially cause bugs downstream. However, the current state of the code is fine because in the function that it is called, the argument passed to it is matched at the top, and errors there.


* **What is the new behaviour (if this is a feature change)?**
  
The functions will now error when there is no match instead of returning `NULL`, which could cause bugs.
  
  
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:

- This PR closes #200. 
- This change is probably unnecessary because the arguments passed to these helpers are checked and would error before being passed down to this function.