### PR TITLE
Fix ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,19 +4,19 @@ Title: Simulating and Analysing Transmission Chain Statistics Using Branching Pr
 Version: 0.0.0.9999
 Authors@R: c(
     person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = c("aut", "cre"),
-           comment = c(ORCID = "https://orcid.org/0000-0001-5782-7330")),
+           comment = c(ORCID = "0000-0001-5782-7330")),
     person("Hugo", "Gruson", , "hugo@data.org", role = c("ctb", "rev"),
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
+           comment = c(ORCID = "0000-0002-4094-1476")),
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0003-1458-7108")),
+           comment = c(ORCID = "0000-0003-1458-7108")),
     person("Flavio", "Finger", , "flavio.finger@epicentre.msf.org", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0002-8613-5170")),
+           comment = c(ORCID = "0000-0002-8613-5170")),
     person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0002-2842-3406")),
+           comment = c(ORCID = "0000-0002-2842-3406")),
     person("Karim", "Mané", , "karim.mane@lshtm.ac.uk", role = "rev",
            comment = c(ORCID = "0000-0002-9892-2999")),
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = "rev",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819"))
+           comment = c(ORCID = "0000-0001-5294-7819"))
            )
 Description: Provides methods to simulate and analyse the size and length
     of branching processes with an arbitrary offspring distribution. These


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126