### PR TITLE
Revise summary.epichains_tree to return <epichains_summary>

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -348,8 +348,8 @@ summary.epichains_tree <- function(object, ...) {
   } else {
     # Length: each case's last sim_id
     for (i in seq_len(index_cases)) {
-      max_case_index <- max(which(object$infectee_id == i))
-      chain_summaries[i] <- object$sim_id[max_case_index]
+      index_case_rows <- which(object$infector_id == i)
+      chain_summaries[i] <- length(unique((object$sim_id[index_case_rows])))
     }
   }
 

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -294,8 +294,8 @@ format.epichains_summary <- function(x, ...) {
 #' @author James M. Azam
 #' @export
 #' @examples
-#' # Using a Negative binomial offspring distribution and simulating from a
-#' finite population up to chain size 10.
+#' # Using a negative binomial offspring distribution and simulating from a
+#' # finite population up to chain size 10.
 #' set.seed(32)
 #' sim_chains_nbinom <- simulate_chains(
 #'   index_cases = 10,
@@ -332,7 +332,7 @@ summary.epichains_tree <- function(object, ...) {
   # Check that object has <epichains_tree> class
   validate_epichains_tree(object)
 
-  # Get relevant attributes (opportunity for a .as_epichains_summary() method?)
+  # Get relevant attributes for computing summaries
   statistic <- attr(object, "statistic")
   index_cases <- attr(object, "index_cases")
   max_sim_id <- max(object$sim_id)
@@ -342,7 +342,7 @@ summary.epichains_tree <- function(object, ...) {
   # Initialize summary statistics
   chain_summaries <- vector(length = index_cases, mode = "integer")
 
-  # Determine the type of statistic
+  # Calculate the chain summary statistics
   if (statistic == "size") {
     # Size: how many times each case appears in the dataset
     for (i in seq_len(index_cases)) {
@@ -358,7 +358,7 @@ summary.epichains_tree <- function(object, ...) {
   # Apply truncation
   chain_summaries[chain_summaries >= stat_max] <- Inf
 
-  # Create an <epichains_summary> object
+  # Return an <epichains_summary> object
   chain_summaries <- epichains_summary(
     chains_summary = chain_summaries,
     index_cases = index_cases,

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -304,7 +304,6 @@ format.epichains_summary <- function(x, ...) {
 #'   statistic = "size",
 #'   offspring_dist = rnbinom,
 #'   stat_max = 10,
-#'   generation_time = function(n) rep(3, n),
 #'   mu = 2,
 #'   size = 0.2
 #' )
@@ -338,22 +337,19 @@ summary.epichains_tree <- function(object, ...) {
 
   # Initialize summary statistics
   chain_summaries <- vector(length = index_cases, mode = "integer")
-
-  # Calculate the chain summary statistics
+  # Calculate the summary statistic based on the specified statistic type
   if (statistic == "size") {
-    # Size: how many times each case appears in the dataset
-    for (i in seq_len(index_cases)) {
-      chain_summaries[i] <- sum(object$infectee_id == i)
-    }
+    # size is the number of infectees produced by a chain before it goes
+    # extinct.
+    chain_summaries <- as.numeric(table(object$infectee_id))
   } else {
-    # Length: each case's last sim_id
+    # length is the number of infectors generations a chain produces before
+    # it goes extinct.
     for (i in seq_len(index_cases)) {
-      index_case_rows <- which(object$infector_id == i)
-      chain_summaries[i] <- length(unique((object$sim_id[index_case_rows])))
+      chain_generations <- object[object$infectee_id == i, "generation"]
+      chain_summaries[i] <- max(chain_generations)
     }
   }
-
-  # Create an <epichains_summary> object
   # Get other required attributes from passed object
   stat_max <- attr(object, "stat_max")
   offspring_dist <- attr(object, "offspring_dist")

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -335,9 +335,6 @@ summary.epichains_tree <- function(object, ...) {
   # Get relevant attributes for computing summaries
   statistic <- attr(object, "statistic")
   index_cases <- attr(object, "index_cases")
-  max_sim_id <- max(object$sim_id)
-  stat_max <- attr(object, "stat_max")
-  offspring_dist <- attr(object, "offspring_dist")
 
   # Initialize summary statistics
   chain_summaries <- vector(length = index_cases, mode = "integer")
@@ -355,6 +352,12 @@ summary.epichains_tree <- function(object, ...) {
       chain_summaries[i] <- object$sim_id[max_case_index]
     }
   }
+
+  # Create an <epichains_summary> object
+  # Get other required attributes from passed object
+  stat_max <- attr(object, "stat_max")
+  offspring_dist <- attr(object, "offspring_dist")
+
   # Apply truncation
   chain_summaries[chain_summaries >= stat_max] <- Inf
 
@@ -366,7 +369,6 @@ summary.epichains_tree <- function(object, ...) {
     offspring_dist = offspring_dist,
     stat_max = stat_max
   )
-
   return(chain_summaries)
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,9 +84,13 @@ on the value of `log`) of observing a vector of transmission chain sizes or
 lengths.
 
 The objects returned by the `simulate_*()` functions can be summarised with
-`summary()` and aggregated into a `<data.frame>` of cases per time or generation
-with `aggregate()`. Aggregated results can also be passed on to `plot()` with
-its own arguments to customize the resulting plots. 
+`summary()`. Running `summary()` on the output of `simulate_chains()` will
+return the same output as `simulate_summary()` using the same inputs.
+
+Objects returned from `simulate_chains()` can be aggregated into a
+`<data.frame>` of cases per time or generation
+with the function `aggregate()`. The aggregated results can also be passed
+on to `plot()` with its own arguments to customize the resulting plots.
 
 Each of the listed functionalities is demonstrated in detail
 in the ["Getting Started" vignette](https://epiverse-trace.github.io/epichains/articles/epichains.html).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- `packagename` is extracted from the DESCRIPTION file -->
 <!-- `gh_repo` is extracted via a special environment variable in GitHub Actions -->
 
-# *{{ packagename }}*: Methods for simulating and analysing the size and length of transmission chains from branching process models <img src="man/figures/logo.svg" align="right" height="130" />
+# *epichains*: Methods for simulating and analysing the size and length of transmission chains from branching process models <img src="man/figures/logo.svg" align="right" height="130" />
 
 <!-- badges: start -->
 
@@ -17,14 +17,14 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
-*{{ packagename }}* is an R package to simulate, analyse, and visualize
-the size and length of branching processes with a given offspring
-distribution. These models are often used in infectious disease
-epidemiology, where the chains represent chains of transmission, and the
-offspring distribution represents the distribution of secondary
-infections caused by an infected individual.
+*epichains* is an R package to simulate, analyse, and visualize the size
+and length of branching processes with a given offspring distribution.
+These models are often used in infectious disease epidemiology, where
+the chains represent chains of transmission, and the offspring
+distribution represents the distribution of secondary infections caused
+by an infected individual.
 
-*{{ packagename }}* re-implements
+*epichains* re-implements
 [bpmodels](https://github.com/epiverse-trace/bpmodels/) by providing
 bespoke functions and data structures that allow easy manipulation and
 interoperability with other Epiverse-TRACE packages, for example,
@@ -33,21 +33,21 @@ interoperability with other Epiverse-TRACE packages, for example,
 potentially some existing packages for handling transmission chains, for
 example, [epicontacts](https://github.com/reconhub/epicontacts).
 
-*{{ packagename }}* is developed at the [Centre for the Mathematical
-Modelling of Infectious
+*epichains* is developed at the [Centre for the Mathematical Modelling
+of Infectious
 Diseases](https://www.lshtm.ac.uk/research/centres/centre-mathematical-modelling-infectious-diseases)
 at the London School of Hygiene and Tropical Medicine as part of the
 [Epiverse Initiative](https://data.org/initiatives/epiverse/).
 
 ## Installation
 
-The latest development version of the *{{ packagename }}* package can be
+The latest development version of the *epichains* package can be
 installed via
 
 ``` r
 # check whether {pak} is installed
 if (!require("pak")) install.packages("pak")
-pak::pak("{{ gh_repo }}")
+pak::pak("epiverse-trace/epichains")
 ```
 
 To load the package, use
@@ -58,7 +58,7 @@ library("epichains")
 
 ## Quick start
 
-*{{ packagename }}* provides two main functions:
+*epichains* provides two main functions:
 
 - `simulate_chains()`: simulates transmission chains using a simple
   branching process model that accepts an index number of cases that
@@ -102,7 +102,7 @@ We have also collated a bibliography of branching process applications
 in epidemiology. These can be found in the [literature
 vignette](https://epiverse-trace.github.io/epichains/articles/branching_process_literature.html).
 
-Specific use cases of *{{ packagename }}* can be found in the [online
+Specific use cases of *epichains* can be found in the [online
 documentation as package
 vignettes](https://epiverse-trace.github.io/epichains/), under
 “Articles”.
@@ -120,8 +120,8 @@ guide](https://github.com/epiverse-trace/epichains/blob/main/.github/CONTRIBUTIN
 
 ## Code of conduct
 
-Please note that the *{{ packagename }}* project is released with a
-[Contributor Code of
+Please note that the *epichains* project is released with a [Contributor
+Code of
 Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md).
 By contributing to this project, you agree to abide by its terms.
 
@@ -131,7 +131,7 @@ By contributing to this project, you agree to abide by its terms.
 citation("epichains")
 #> To cite package 'epichains' in publications use:
 #> 
-#>   Azam J, Finger F, Funk S (????). _epichains: Simulating and Analysing
+#>   Azam J, Finger F, Funk S (2024). _epichains: Simulating and Analysing
 #>   Transmission Chain Statistics Using Branching Process Models_. R
 #>   package version 0.0.0.9999,
 #>   https://epiverse-trace.github.io/epichains/,
@@ -140,9 +140,10 @@ citation("epichains")
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
-#>     title = {epichains: Simulating and Analysing Transmission Chain Statistics Using Branching Process
-#> Models},
+#>     title = {epichains: Simulating and Analysing Transmission Chain Statistics Using
+#> Branching Process Models},
 #>     author = {James M. Azam and Flavio Finger and Sebastian Funk},
+#>     year = {2024},
 #>     note = {R package version 0.0.0.9999, 
 #> https://epiverse-trace.github.io/epichains/},
 #>     url = {https://github.com/epiverse-trace/epichains},

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- `packagename` is extracted from the DESCRIPTION file -->
 <!-- `gh_repo` is extracted via a special environment variable in GitHub Actions -->
 
-# *epichains*: Methods for simulating and analysing the size and length of transmission chains from branching process models <img src="man/figures/logo.svg" align="right" height="130" />
+# *{{ packagename }}*: Methods for simulating and analysing the size and length of transmission chains from branching process models <img src="man/figures/logo.svg" align="right" height="130" />
 
 <!-- badges: start -->
 
@@ -17,14 +17,14 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
-*epichains* is an R package to simulate, analyse, and visualize the size
-and length of branching processes with a given offspring distribution.
-These models are often used in infectious disease epidemiology, where
-the chains represent chains of transmission, and the offspring
-distribution represents the distribution of secondary infections caused
-by an infected individual.
+*{{ packagename }}* is an R package to simulate, analyse, and visualize
+the size and length of branching processes with a given offspring
+distribution. These models are often used in infectious disease
+epidemiology, where the chains represent chains of transmission, and the
+offspring distribution represents the distribution of secondary
+infections caused by an infected individual.
 
-*epichains* re-implements
+*{{ packagename }}* re-implements
 [bpmodels](https://github.com/epiverse-trace/bpmodels/) by providing
 bespoke functions and data structures that allow easy manipulation and
 interoperability with other Epiverse-TRACE packages, for example,
@@ -33,21 +33,21 @@ interoperability with other Epiverse-TRACE packages, for example,
 potentially some existing packages for handling transmission chains, for
 example, [epicontacts](https://github.com/reconhub/epicontacts).
 
-*epichains* is developed at the [Centre for the Mathematical Modelling
-of Infectious
+*{{ packagename }}* is developed at the [Centre for the Mathematical
+Modelling of Infectious
 Diseases](https://www.lshtm.ac.uk/research/centres/centre-mathematical-modelling-infectious-diseases)
 at the London School of Hygiene and Tropical Medicine as part of the
 [Epiverse Initiative](https://data.org/initiatives/epiverse/).
 
 ## Installation
 
-The latest development version of the *epichains* package can be
+The latest development version of the *{{ packagename }}* package can be
 installed via
 
 ``` r
 # check whether {pak} is installed
 if (!require("pak")) install.packages("pak")
-pak::pak("epiverse-trace/epichains")
+pak::pak("{{ gh_repo }}")
 ```
 
 To load the package, use
@@ -58,7 +58,7 @@ library("epichains")
 
 ## Quick start
 
-*epichains* provides two main functions:
+*{{ packagename }}* provides two main functions:
 
 - `simulate_chains()`: simulates transmission chains using a simple
   branching process model that accepts an index number of cases that
@@ -71,7 +71,7 @@ library("epichains")
   a generation time function is specified, the time of infection.
 
 - `simulate_summary()`: provides a performant version of
-  `simulate_chains()` that only tracks and returns a vector of realized
+  `simulate_chains()` that only tracks and return a vector of realized
   chain sizes or lengths/durations for each index case without details
   of the infection tree.
 
@@ -80,9 +80,14 @@ library("epichains")
   sizes or lengths.
 
 The objects returned by the `simulate_*()` functions can be summarised
-with `summary()` and aggregated into a `<data.frame>` of cases per time
-or generation with `aggregate()`. Aggregated results can also be passed
-on to `plot()` with its own arguments to customize the resulting plots.
+with `summary()`. Running `summary()` on the output of
+`simulate_chains()` will return the same output as `simulate_summary()`
+using the same inputs.
+
+Objects returned from `simulate_chains()` can be aggregated into a
+`<data.frame>` of cases per time or generation with the function
+`aggregate()`. The aggregated results can also be passed on to `plot()`
+with its own arguments to customize the resulting plots.
 
 Each of the listed functionalities is demonstrated in detail in the
 [“Getting Started”
@@ -97,7 +102,7 @@ We have also collated a bibliography of branching process applications
 in epidemiology. These can be found in the [literature
 vignette](https://epiverse-trace.github.io/epichains/articles/branching_process_literature.html).
 
-Specific use cases of *epichains* can be found in the [online
+Specific use cases of *{{ packagename }}* can be found in the [online
 documentation as package
 vignettes](https://epiverse-trace.github.io/epichains/), under
 “Articles”.
@@ -115,8 +120,8 @@ guide](https://github.com/epiverse-trace/epichains/blob/main/.github/CONTRIBUTIN
 
 ## Code of conduct
 
-Please note that the *epichains* project is released with a [Contributor
-Code of
+Please note that the *{{ packagename }}* project is released with a
+[Contributor Code of
 Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md).
 By contributing to this project, you agree to abide by its terms.
 
@@ -126,7 +131,7 @@ By contributing to this project, you agree to abide by its terms.
 citation("epichains")
 #> To cite package 'epichains' in publications use:
 #> 
-#>   Azam J, Finger F, Funk S (2024). _epichains: Simulating and Analysing
+#>   Azam J, Finger F, Funk S (????). _epichains: Simulating and Analysing
 #>   Transmission Chain Statistics Using Branching Process Models_. R
 #>   package version 0.0.0.9999,
 #>   https://epiverse-trace.github.io/epichains/,
@@ -135,10 +140,9 @@ citation("epichains")
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
-#>     title = {epichains: Simulating and Analysing Transmission Chain Statistics Using
-#> Branching Process Models},
+#>     title = {epichains: Simulating and Analysing Transmission Chain Statistics Using Branching Process
+#> Models},
 #>     author = {James M. Azam and Flavio Finger and Sebastian Funk},
-#>     year = {2024},
 #>     note = {R package version 0.0.0.9999, 
 #> https://epiverse-trace.github.io/epichains/},
 #>     url = {https://github.com/epiverse-trace/epichains},

--- a/man/summary.epichains_tree.Rd
+++ b/man/summary.epichains_tree.Rd
@@ -25,8 +25,8 @@ chains and returns an object with the same information as that returned
 by an equivalent \code{simulate_summary()} call.
 }
 \examples{
-# Using a Negative binomial offspring distribution and simulating from a
-finite population up to chain size 10.
+# Using a negative binomial offspring distribution and simulating from a
+# finite population up to chain size 10.
 set.seed(32)
 sim_chains_nbinom <- simulate_chains(
   index_cases = 10,

--- a/man/summary.epichains_tree.Rd
+++ b/man/summary.epichains_tree.Rd
@@ -12,10 +12,53 @@
 \item{...}{ignored}
 }
 \value{
-List of summaries
+An \verb{<epichains_summary>} object containing the chain summary
+statistics as follows:
+"size": the total number of cases produced by a chain before it
+goes extinct.
+"length": the total number of infectors produced by a chain before
+it goes extinct.
 }
 \description{
-Summary method for \verb{<epichains_tree>} class
+This calculates the chain statistic (size/length) for the simulated
+chains and returns an object with the same information as that returned
+by an equivalent \code{simulate_summary()} call.
+}
+\examples{
+# Using a Negative binomial offspring distribution and simulating from a
+finite population up to chain size 10.
+set.seed(32)
+sim_chains_nbinom <- simulate_chains(
+  index_cases = 10,
+  pop = 100,
+  percent_immune = 0,
+  statistic = "size",
+  offspring_dist = rnbinom,
+  stat_max = 10,
+  generation_time = function(n) rep(3, n),
+  mu = 2,
+  size = 0.2
+)
+# Summarise the simulated chains
+sim_chains_nbinom_summary <- summary(sim_chains_nbinom)
+sim_chains_nbinom_summary
+
+# Same results can be obtained using `simulate_summary()`
+set.seed(32)
+sim_summary_nbinom <- simulate_summary(
+  index_cases = 10,
+  pop = 100,
+  percent_immune = 0,
+  statistic = "size",
+  offspring_dist = rnbinom,
+  stat_max = 10,
+  mu = 2,
+  size = 0.2
+)
+sim_summary_nbinom
+
+# Check that the results are the same
+setequal(sim_chains_nbinom_summary, sim_summary_nbinom)
 }
 \author{
 James M. Azam

--- a/man/summary.epichains_tree.Rd
+++ b/man/summary.epichains_tree.Rd
@@ -35,7 +35,6 @@ sim_chains_nbinom <- simulate_chains(
   statistic = "size",
   offspring_dist = rnbinom,
   stat_max = 10,
-  generation_time = function(n) rep(3, n),
   mu = 2,
   size = 0.2
 )

--- a/tests/testthat/_snaps/epichains.md
+++ b/tests/testthat/_snaps/epichains.md
@@ -17,7 +17,7 @@
       
       
       Trees simulated: 10
-      Number of infectors (known): 7
+      Number of infectors (known): 8
       Number of generations: 6
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -31,17 +31,17 @@
       < tree head (from first known infector_id) >
       
          infectee_id sim_id infector_id generation       time susc_pop
-      11           3      2           1          2 0.86230340       86
-      12           4      2           1          2 0.04755749       86
-      13           7      2           1          2 0.71374277       86
-      14          10      2           1          2 5.76461704       86
-      15           3      3           2          3 1.29009990       83
-      16           7      3           2          3 1.13146371       83
+      11           1      2           1          2  6.5291176       82
+      12           3      2           1          2  4.5366156       82
+      13           4      2           1          2  0.4951176       82
+      14           6      2           1          2  8.9518883       82
+      15           7      2           1          2 20.7565268       82
+      16           8      2           1          2  8.4553011       82
       
       
       Trees simulated: 10
-      Number of infectors (known): 5
-      Number of generations: 6
+      Number of infectors (known): 4
+      Number of generations: 4
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
 ---
@@ -53,13 +53,18 @@
       
       < tree head (from first known infector_id) >
       
-      [1] infectee_id sim_id      infector_id generation 
-      <0 rows> (or 0-length row.names)
+        infectee_id sim_id infector_id generation
+      3           1      2           1          2
+      4           2      2           1          2
+      5           1      3           2          3
+      6           2      3           2          3
+      7           1      4           2          3
+      8           2      4           3          4
       
       
       Trees simulated: 2
-      Number of infectors (known): 0
-      Number of generations: 1
+      Number of infectors (known): 60
+      Number of generations: 15
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
 ---
@@ -72,17 +77,17 @@
       < tree head (from first known infector_id) >
       
          infectee_id sim_id infector_id generation       time
-      11           1      2           1          2 48.7001430
-      12           2      2           1          2  3.3254875
-      13           3      2           1          2 14.1529291
-      14           4      2           1          2  0.6986002
-      15           5      2           1          2  7.1331106
-      16           6      2           1          2  0.7425929
+      11           1      2           1          2 1.16906106
+      12           2      2           1          2 1.93214311
+      13           3      2           1          2 7.87852902
+      14           4      2           1          2 5.75296347
+      15           5      2           1          2 7.19513227
+      16           6      2           1          2 0.06998357
       
       
       Trees simulated: 10
       Number of infectors (known): 9
-      Number of generations: 5
+      Number of generations: 7
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
 ---
@@ -92,12 +97,12 @@
     Output
       `epichains_summary` object 
       
-      [1] 1 1
+      [1] 15  5
       
        Simulated tree lengths: 
       
-      Max: 1
-      Min: 1
+      Max: 15
+      Min: 5
 
 # head and tail print output as expected
 

--- a/tests/testthat/_snaps/simulate.md
+++ b/tests/testthat/_snaps/simulate.md
@@ -31,7 +31,7 @@
       
       
       Trees simulated: 10
-      Number of infectors (known): 5
+      Number of infectors (known): 6
       Number of generations: 5
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -54,7 +54,7 @@
       
       
       Trees simulated: 10
-      Number of infectors (known): 97
+      Number of infectors (known): 98
       Number of generations: 12
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 
@@ -72,7 +72,7 @@
       
       
       Trees simulated: 10
-      Number of infectors (known): 1
+      Number of infectors (known): 2
       Number of generations: 2
       Use `as.data.frame(<object_name>)` to view the full output in the console.
 

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -209,6 +209,18 @@ test_that("summary.epichains_tree works as expected", {
     chain_size_tree_sim_summary,
     "epichains_summary"
   )
+  expect_true(
+    setequal(
+      chain_size_tree_sim_summary,
+      chain_size_summary_sim
+    )
+  )
+  expect_true(
+    setequal(
+      chain_length_tree_sim_summary,
+      chain_length_summary_sim
+    )
+  )
 })
 
 test_that("validate_epichains_tree works", {

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -126,6 +126,7 @@ test_that("print.epichains_tree works for simulation functions", {
     generation_time = generation_time_fn
   )
   #' Simulate an outbreak from a susceptible population (nbinom)
+  set.seed(32)
   susc_outbreak_raw2 <- simulate_chains(
     pop = 100,
     index_cases = 10,
@@ -136,6 +137,7 @@ test_that("print.epichains_tree works for simulation functions", {
     generation_time = generation_time_fn
   )
   #' Simulate a tree of infections without serials
+  set.seed(32)
   tree_sim_raw <- simulate_chains(
     index_cases = 2,
     offspring_dist = rpois,
@@ -143,6 +145,7 @@ test_that("print.epichains_tree works for simulation functions", {
     lambda = 0.9
   )
   #' Simulate a tree of infections with generation times
+  set.seed(32)
   tree_sim_raw2 <- simulate_chains(
     index_cases = 10,
     statistic = "size",
@@ -152,6 +155,7 @@ test_that("print.epichains_tree works for simulation functions", {
     lambda = 2
   )
   #' Simulate chain statistics
+  set.seed(32)
   chain_summary_raw <- simulate_summary(
     index_cases = 2,
     offspring_dist = rpois,
@@ -174,9 +178,11 @@ test_that("summary.epichains_tree works as expected", {
   # get the summary
   chain_size_tree_sim_summary <- summary(chain_size_tree_sim)
   #' Simulate the size statistic for the same outbreak
+  set.seed(32)
   chain_size_summary_sim <- simulate_summary_default()
   #' Simulate an outbreak from a susceptible population (pois), tracking
   #' the chain lengths
+  set.seed(32)
   chain_length_tree_sim <- simulate_chains_default(
     generation_time = NULL,
     statistic = "length"
@@ -184,6 +190,7 @@ test_that("summary.epichains_tree works as expected", {
   # get the summary
   chain_length_tree_sim_summary <- summary(chain_length_tree_sim)
   #' Simulate the length statistic for the same outbreak
+  set.seed(32)
   chain_length_summary_sim <- simulate_summary_default(statistic = "length")
   #' Expect the results from the tree and the summary to be the same
   expect_true(

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -295,20 +295,26 @@ test_that("simulate_chains is numerically correct", {
   sim_chains_summary <- summary(sim_chains_small_susc)
   #' Expectations
   expect_identical(
-    sim_chains_summary$index_cases,
-    10.00
+    max(sim_chains_summary),
+    5
   )
   expect_identical(
-    sim_chains_summary$unique_infectors,
-    5L
+    as.vector(sim_chains_summary),
+    c(3, 5, 2, 3, 2, 2, 2, 1, 2, 2)
   )
   expect_identical(
-    sim_chains_summary$max_generation,
-    5L
+    min(sim_chains_summary),
+    1
   )
+  # each index case has a single summary value so expect the length of the
+  # summary vector to be equal to the number of index cases.
   expect_identical(
-    max(sim_chains_small_susc$sim_id),
-    7
+    length(sim_chains_summary),
+    as.integer(attr(sim_chains_summary, "index_cases"))
+  )
+  expect_s3_class(
+    sim_chains_summary,
+    "epichains_summary"
   )
 })
 

--- a/vignettes/epichains.Rmd
+++ b/vignettes/epichains.Rmd
@@ -279,7 +279,8 @@ simulate_summary_eg
 
 ### Summarising
 
-You can run `summary()` on `<epichains_tree>` objects to get useful summaries.
+You can run `summary()` on the object returned by `simulate_chains()` to
+obtain the chain summaries per index case.
 ```{r include=TRUE,echo=TRUE}
 set.seed(32)
 # Define generation time
@@ -300,7 +301,7 @@ sim_chains <- simulate_chains(
 summary(sim_chains)
 
 # Example with simulate_summary()
-set.seed(123)
+set.seed(32)
 
 simulate_summary_eg <- simulate_summary(
   index_cases = 10,
@@ -312,6 +313,23 @@ simulate_summary_eg <- simulate_summary(
 
 # Get summaries
 summary(simulate_summary_eg)
+```
+
+This summary is the same as the output of `simulate_summary()` if the same
+inputs are used. `simulate_summary()` is a more performant version of
+`simulate_chains()`, hence, you can use it instead, if you are only interested
+in the summary of the simulated chains without details about the infection
+tree.
+
+We can confirm if the two outputs are the same using `base::setequal()`
+
+```{r include=TRUE,echo=TRUE}
+setequal(
+  # summary of output from simulate_chains()
+  summary(sim_chains),
+  # results from simulate_summary()
+  simulate_summary_eg
+)
 ```
 
 ### Aggregating


### PR DESCRIPTION
* **Please check if the PR fulfils these requirements**
  
- [x] I have read the CONTRIBUTING guidelines 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A feature.

* **What is the current behaviour?** (You can also link to an open issue here)

`summary.epichains_tree` method calculates the max generation, number of unique infectors from the `<epichains_tree>` object.

* **What is the new behaviour (if this is a feature change)?**
 
The `summary.epichains_tree` now returns `epichains_summary` with the same results as `simulate_summary()`
  
  
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, since this package is not released.

* **Other information**:

This PR closes #119.