### PR TITLE
Make `rborel()` return a numeric vector instead of an `<epichains_summary>` object

### DIFF
--- a/R/borel.r
+++ b/R/borel.r
@@ -63,7 +63,7 @@ rborel <- function(n, mu, infinite = Inf) {
 ##' @param prob probability of success (in the parameterisation with
 ##'   \code{prob}, see also \code{\link[stats]{NegBinomial}})
 ##' @param mu mean parameter
-##' @return Vector of random numbers
+##' @return Numeric vector of random numbers
 ##' @author Sebastian Funk
 ##' @export
 rgborel <- function(n, size, prob, mu, infinite = Inf) {

--- a/R/borel.r
+++ b/R/borel.r
@@ -50,6 +50,7 @@ rborel <- function(n, mu, infinite = Inf) {
     stat_max = infinite,
     lambda = mu
   )
+  out <- as.numeric(out)
   return(out)
 }
 

--- a/man/rgborel.Rd
+++ b/man/rgborel.Rd
@@ -21,7 +21,7 @@ applications)}
 stopped if this number is reached}
 }
 \value{
-Vector of random numbers
+Numeric vector of random numbers
 }
 \description{
 Generate random numbers from a Gamma-Borel mixture distribution

--- a/tests/testthat/tests-borel.r
+++ b/tests/testthat/tests-borel.r
@@ -4,6 +4,15 @@ test_that("We can calculate probabilities and sample", {
   expect_identical(dborel(1, 0.5, log = TRUE), -0.5)
   expect_length(rborel(2, 0.9), 2)
   expect_length(rgborel(2, 0.5, 0.9), 2)
+  expect_true(
+    class(rborel(2, 0.9)) == "numeric"
+  )
+  expect_true(
+    class(rgborel(2, 0.5, 0.9)) == "numeric"
+  )
+  expect_true(
+    class(dborel(1, 0.5)) == "numeric"
+  )
 })
 
 test_that("Errors are thrown", {


### PR DESCRIPTION
This PR closes #191.
 
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)

`rborel()` returns an object of class `<epichains_summary>`

* **What is the new behavior (if this is a feature change)?**

`rborel()` now returns a numeric vector.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not applicable.

* **Other information**:
