### PR TITLE
Move `obs_prob` next to `nsim_obs` for logical flow in `likelihood()` signature

### DIFF
--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -5,9 +5,9 @@
 #' @param chains Vector of chain summaries (sizes/lengths)
 #' @param nsim_obs Number of simulations if the log-likelihood/likelihood is to
 #' be approximated for imperfect observations.
+#' @param obs_prob Observation probability (assumed constant)
 #' @param log Logical; Should the log-likelihoods be transformed to
 #' likelihoods? (Defaults to TRUE).
-#' @param obs_prob Observation probability (assumed constant)
 #' @param exclude A vector of indices of the sizes/lengths to exclude from the
 #' log-likelihood calculation.
 #' @param individual If TRUE, a vector of individual log-likelihood/likelihood
@@ -42,7 +42,7 @@
 #' )
 #' @export
 likelihood <- function(chains, statistic = c("size", "length"), offspring_dist,
-                       nsim_obs, log = TRUE, obs_prob = 1, stat_max = Inf,
+                       nsim_obs, obs_prob = 1, log = TRUE, stat_max = Inf,
                        exclude = NULL, individual = FALSE, ...) {
   statistic <- match.arg(statistic)
 

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -9,8 +9,8 @@ likelihood(
   statistic = c("size", "length"),
   offspring_dist,
   nsim_obs,
-  log = TRUE,
   obs_prob = 1,
+  log = TRUE,
   stat_max = Inf,
   exclude = NULL,
   individual = FALSE,
@@ -42,10 +42,10 @@ binomial offspring, or custom functions.}
 \item{nsim_obs}{Number of simulations if the log-likelihood/likelihood is to
 be approximated for imperfect observations.}
 
+\item{obs_prob}{Observation probability (assumed constant)}
+
 \item{log}{Logical; Should the log-likelihoods be transformed to
 likelihoods? (Defaults to TRUE).}
-
-\item{obs_prob}{Observation probability (assumed constant)}
 
 \item{stat_max}{A cut off for the chain statistic (size/length) being
 computed. Results above the specified value, are set to \code{Inf}.}


### PR DESCRIPTION
This PR closes #134 by moving `obs_prob` next to `nsim_obs` for logical flow in the arguments of `likelihood()`. This order makes sense because a user will have to specify `nsim_obs` if they change the default `obs_prob`.
