### PR TITLE
dependabot workflow: Fix "label" option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
       day: "monday"
       time: "06:00"
     labels:
-      - "package_infrastructure"
+      - "pkg_infrastructure"


### PR DESCRIPTION
This PR fixes the label option in the Dependabot workflow. It was wrongly specified as "package_infrastructure" instead of "pkg_infrastructrue".