### PR TITLE
Improve documentation of `nsim_obs` and `obs_prob`

### DIFF
--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -6,6 +6,11 @@
 #' @param nsim_obs Number of simulations to be used to approximate the
 #' log-likelihood/likelihood if `obs_prob < 1` (imperfect observation). If
 #' `obs_prob == 1`, this argument is ignored.
+#' @param obs_prob Observation probability. A number (probability) between 0
+#' and 1. A value greater than 0 but less 1 implies imperfect observation and
+#' simulations will be used to approximate the (log)likelihood. This will
+#' also require specifying `nsim_obs`. In the simulation, the observation
+#' process is assumed to be constant.
 #' @param log Logical; Should the log-likelihoods be transformed to
 #' likelihoods? (Defaults to TRUE).
 #' @param exclude A vector of indices of the sizes/lengths to exclude from the

--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -3,9 +3,9 @@
 #' @inheritParams offspring_ll
 #' @inheritParams simulate_summary
 #' @param chains Vector of chain summaries (sizes/lengths)
-#' @param nsim_obs Number of simulations if the log-likelihood/likelihood is to
-#' be approximated for imperfect observations.
-#' @param obs_prob Observation probability (assumed constant)
+#' @param nsim_obs Number of simulations to be used to approximate the
+#' log-likelihood/likelihood if `obs_prob < 1` (imperfect observation). If
+#' `obs_prob == 1`, this argument is ignored.
 #' @param log Logical; Should the log-likelihoods be transformed to
 #' likelihoods? (Defaults to TRUE).
 #' @param exclude A vector of indices of the sizes/lengths to exclude from the

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -43,7 +43,11 @@ binomial offspring, or custom functions.}
 log-likelihood/likelihood if \code{obs_prob < 1} (imperfect observation). If
 \code{obs_prob == 1}, this argument is ignored.}
 
-\item{obs_prob}{Observation probability (assumed constant)}
+\item{obs_prob}{Observation probability. A number (probability) between 0
+and 1. A value greater than 0 but less 1 implies imperfect observation and
+simulations will be used to approximate the (log)likelihood. This will
+also require specifying \code{nsim_obs}. In the simulation, the observation
+process is assumed to be constant.}
 
 \item{log}{Logical; Should the log-likelihoods be transformed to
 likelihoods? (Defaults to TRUE).}

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -39,8 +39,9 @@ on to the random number generating functions. Examples that can be provided
 here are \code{rpois} for Poisson distributed offspring, \code{rnbinom} for negative
 binomial offspring, or custom functions.}
 
-\item{nsim_obs}{Number of simulations if the log-likelihood/likelihood is to
-be approximated for imperfect observations.}
+\item{nsim_obs}{Number of simulations to be used to approximate the
+log-likelihood/likelihood if \code{obs_prob < 1} (imperfect observation). If
+\code{obs_prob == 1}, this argument is ignored.}
 
 \item{obs_prob}{Observation probability (assumed constant)}
 


### PR DESCRIPTION
This PR closes #231 by improving the documentation of `nsim_obs` and `obs_prob` so that it is clear that they are linked. The improvement also adds some interpretation to the arguments. 
