### PR TITLE
Make `summary` find max of all values including `Inf` and print `>= stat_max` if max is `Inf` 

### DIFF
--- a/R/epichains.R
+++ b/R/epichains.R
@@ -199,11 +199,11 @@ print.epichains <- function(x, ...) {
 #' @param x An `<epichains_summary>` object.
 #' @description
 #' Prints a summary of the `<epichains_summary>` object. In particular, it
-#' prints the number of index cases used for the simulation, and range of
-#' the statistic, represented as the maximum and minimum. If the maximum
-#' is infinite, it is represented as `>= stat_max` where `stat_max` is the
-#' value of the censoring limit. See `?epichains_summary()` for the definition
-#' of `stat_max`.
+#' prints the number of index cases used for the simulation, and the range of
+#' the statistic, represented as the maximum (`max_stat`) and minimum
+#' (`min_stat`). If the minimum or maximum is infinite, it is represented as
+#' `>= stat_max` where `stat_max` is the value of the censoring limit. See
+#' `?epichains_summary()` for the definition of `stat_max`.
 #' @param ... Not used.
 #' @return Invisibly returns an `<epichains_summary>`. Called for
 #' side-effects.

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -304,7 +304,13 @@ format.epichains_summary <- function(x, ...) {
       ),
       sprintf(
         "Min: %s",
-        statistics[["min_stat"]]
+        ifelse(
+          is.infinite(
+            statistics[["min_stat"]]),
+          paste0(">=", attr(x, "stat_max")
+          ),
+          statistics[["min_stat"]]
+        )
       )
     )
   )

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -197,6 +197,13 @@ print.epichains <- function(x, ...) {
 #' Print an `<epichains_summary>` object
 #'
 #' @param x An `<epichains_summary>` object.
+#' @description
+#' Prints a summary of the `<epichains_summary>` object. In particular, it
+#' prints the number of index cases used for the simulation, and range of
+#' the statistic, represented as the maximum and minimum. If the maximum
+#' is infinite, it is represented as `>= stat_max` where `stat_max` is the
+#' value of the censoring limit. See `?epichains_summary()` for the definition
+#' of `stat_max`.
 #' @param ... Not used.
 #' @return Invisibly returns an `<epichains_summary>`. Called for
 #' side-effects.

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -287,7 +287,12 @@ format.epichains_summary <- function(x, ...) {
       ),
       sprintf(
         "Max: %s",
-        statistics[["max_stat"]]
+        ifelse(
+          is.infinite(
+            statistics[["max_stat"]]),
+          paste0(">=", attr(x, "stat_max")),
+          statistics[["max_stat"]]
+        )
       ),
       sprintf(
         "Min: %s",

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -416,8 +416,8 @@ summary.epichains_summary <- function(object, ...) {
   if (all(is.infinite(object))) {
     max_stat <- min_stat <- Inf
   } else {
-    max_stat <- max(object[!is.infinite(object)])
-    min_stat <- min(object[!is.infinite(object)])
+    max_stat <- max(object)
+    min_stat <- min(object)
   }
 
   out <- list(

--- a/R/epichains.R
+++ b/R/epichains.R
@@ -297,7 +297,8 @@ format.epichains_summary <- function(x, ...) {
         ifelse(
           is.infinite(
             statistics[["max_stat"]]),
-          paste0(">=", attr(x, "stat_max")),
+            paste0(">=", attr(x, "stat_max")
+          ),
           statistics[["max_stat"]]
         )
       ),

--- a/man/print.epichains_summary.Rd
+++ b/man/print.epichains_summary.Rd
@@ -17,11 +17,11 @@ side-effects.
 }
 \description{
 Prints a summary of the \verb{<epichains_summary>} object. In particular, it
-prints the number of index cases used for the simulation, and range of
-the statistic, represented as the maximum and minimum. If the maximum
-is infinite, it is represented as \verb{>= stat_max} where \code{stat_max} is the
-value of the censoring limit. See \code{?epichains_summary()} for the definition
-of \code{stat_max}.
+prints the number of index cases used for the simulation, and the range of
+the statistic, represented as the maximum (\code{max_stat}) and minimum
+(\code{min_stat}). If the minimum or maximum is infinite, it is represented as
+\verb{>= stat_max} where \code{stat_max} is the value of the censoring limit. See
+\code{?epichains_summary()} for the definition of \code{stat_max}.
 }
 \author{
 James M. Azam

--- a/man/print.epichains_summary.Rd
+++ b/man/print.epichains_summary.Rd
@@ -16,7 +16,12 @@ Invisibly returns an \verb{<epichains_summary>}. Called for
 side-effects.
 }
 \description{
-Print an \verb{<epichains_summary>} object
+Prints a summary of the \verb{<epichains_summary>} object. In particular, it
+prints the number of index cases used for the simulation, and range of
+the statistic, represented as the maximum and minimum. If the maximum
+is infinite, it is represented as \verb{>= stat_max} where \code{stat_max} is the
+value of the censoring limit. See \code{?epichains_summary()} for the definition
+of \code{stat_max}.
 }
 \author{
 James M. Azam

--- a/tests/testthat/_snaps/epichains.md
+++ b/tests/testthat/_snaps/epichains.md
@@ -104,6 +104,20 @@
       Max: 15
       Min: 5
 
+---
+
+    Code
+      chain_lengths_with_Infs
+    Output
+      `epichains_summary` object 
+      
+       [1]   8   2 Inf   8   1 Inf   8 Inf   2   3
+      
+       Simulated tree lengths: 
+      
+      Max: >=10
+      Min: 1
+
 # head and tail print output as expected
 
     Code

--- a/tests/testthat/_snaps/epichains.md
+++ b/tests/testthat/_snaps/epichains.md
@@ -118,6 +118,20 @@
       Max: >=10
       Min: 1
 
+---
+
+    Code
+      chain_lengths_all_Infs
+    Output
+      `epichains_summary` object 
+      
+      [1] Inf Inf
+      
+       Simulated tree lengths: 
+      
+      Max: >=10
+      Min: >=10
+
 # head and tail print output as expected
 
     Code

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -162,12 +162,22 @@ test_that("print.epichains works for simulation functions", {
     statistic = "length",
     lambda = 0.9
   )
+  #' Simulate the case where Infs are produced and printed as ">= stat_max"
+  set.seed(32)
+  chain_lengths_with_Infs <- simulate_summary(
+    index_cases = 10,
+    offspring_dist = rpois,
+    statistic = "length",
+    lambda = 1.1,
+    stat_max = 10
+  )
   #' Expectations
   expect_snapshot(susc_outbreak_raw)
   expect_snapshot(susc_outbreak_raw2)
   expect_snapshot(tree_sim_raw)
   expect_snapshot(tree_sim_raw2)
   expect_snapshot(chain_summary_raw)
+  expect_snapshot(chain_lengths_with_Infs)
 })
 
 test_that("summary.epichains works as expected", {

--- a/tests/testthat/test-epichains.R
+++ b/tests/testthat/test-epichains.R
@@ -171,6 +171,15 @@ test_that("print.epichains works for simulation functions", {
     lambda = 1.1,
     stat_max = 10
   )
+  #' Simulate the case where all are Infs printed as ">= stat_max"
+  set.seed(32)
+  chain_lengths_all_Infs <- simulate_summary(
+    index_cases = 2,
+    offspring_dist = rpois,
+    statistic = "length",
+    lambda = 1.1,
+    stat_max = 10
+  )
   #' Expectations
   expect_snapshot(susc_outbreak_raw)
   expect_snapshot(susc_outbreak_raw2)
@@ -178,6 +187,7 @@ test_that("print.epichains works for simulation functions", {
   expect_snapshot(tree_sim_raw2)
   expect_snapshot(chain_summary_raw)
   expect_snapshot(chain_lengths_with_Infs)
+  expect_snapshot(chain_lengths_all_Infs)
 })
 
 test_that("summary.epichains works as expected", {


### PR DESCRIPTION
This PR closes #239.
 
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Enhancement.


* **What is the current behavior?** (You can also link to an open issue here)

The summary method finds the max of only the finite values.

* **What is the new behavior (if this is a feature change)?**

The summary method now returns the max of all the values but prints the max as `>= stat_max` if the max was `Inf`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NA

* **Other information**:
