### PR TITLE
`tf` should be `t0` in vignette on projecting incidence 

### DIFF
--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -86,7 +86,7 @@ days_since_index
 
 Using the vector of start times from the time series, we will then 
 create a corresponding seeding time for each individual, which we'll call
-`tf`.
+`t0`.
 ```{r t0_setup}
 t0 <- rep(days_since_index, seed_cases$cases)
 t0


### PR DESCRIPTION
This PR makes a minor correction to the vignette on projecting incidence where an object was referred to as `tf` instead of `t0`.
