### PR TITLE
Collapse the "Related Packages" section in the README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -164,6 +164,10 @@ the [online documentation as package vignettes](https://epiverse-trace.github.io
 As far as we know, below are the existing R packages for simulating branching
 processes and transmission chains. 
 
+<details>
+
+<summary>Click to expand</summary>
+
 * [bpmodels](https://github.com/epiverse-trace/bpmodels): provides methods 
 for analysing the size and length of transmission chains from branching 
 process models. `{epichains}` is intended to supersede `{bpmodels}`.
@@ -236,6 +240,7 @@ but relatively intuitive epidemiological simulations.
 
 * [TransPhylo](https://xavierdidelot.github.io/TransPhylo/index.html):
 reconstructs infectious disease transmission using genomic data.
+</details>
 
 ## Reporting bugs 
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ vignettes](https://epiverse-trace.github.io/epichains/), under
 As far as we know, below are the existing R packages for simulating
 branching processes and transmission chains.
 
+<details>
+<summary>
+Click to expand
+</summary>
+
 - [bpmodels](https://github.com/epiverse-trace/bpmodels): provides
   methods for analysing the size and length of transmission chains from
   branching process models. `{epichains}` is intended to supersede
@@ -287,6 +292,8 @@ branching processes and transmission chains.
 
 - [TransPhylo](https://xavierdidelot.github.io/TransPhylo/index.html):
   reconstructs infectious disease transmission using genomic data.
+
+</details>
 
 ## Reporting bugs
 


### PR DESCRIPTION
This PR seeks to collapse the "Related Packages" section to reduce the amount of text in the README at a glance. The list can be accessed by clicking on "Click to expand". This will improve the focus of the README on the package's functionality. 
