### PR TITLE
Remove pkgdown config `as_is = TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # epichains (development version)
 
+## Package
+
+- Removed the `as_is = TRUE` setting in vignette YAML headers to avoid partial incompatibility with incoming pkgdown versions.
+
 # epichains 0.1.0
 
 We are excited to announce the first minor release of `{epichains}`.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,6 +2,7 @@ Blumberg
 Borel
 CMD
 COVID
+Codecov
 Epiverse
 Eq
 Inf
@@ -13,6 +14,7 @@ Poisson
 R's
 TransPhylo
 Vukosi
+YAML
 Zhian
 borel
 bpmodels
@@ -28,10 +30,12 @@ fn
 frac
 geosocial
 geq
+gh
 infectee
 infectees
 infector
 infectors
+io
 json
 kS
 linelist
@@ -45,12 +49,14 @@ outbreaker
 outbreakr
 packagename
 parameterised
+pkgdown
 poisson
 rborel
 ringbp
 simulacr
 simulist
 superspreading
+svg
 th
 truncdist
 unnormalised

--- a/vignettes/branching_process_literature.Rmd
+++ b/vignettes/branching_process_literature.Rmd
@@ -4,8 +4,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: branching_process_literature.json
 link-citations: true
 vignette: >

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Design Principles for {epichains}"
 subtitle: "An R package for simulating, handling, and analysing transmission chains in R"
-pkgdown:
-  as_is: true
 bibliography: references.json
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs fix.


* **What is the current behavior?** (You can also link to an open issue here)

Some vignettes have pkgdown `as_is = TRUE` in their YAMLs. The reason was to allow the use of other features not provided by the HTML rendering format. See https://pkgdown.r-lib.org/reference/build_articles.html#output-formats.

* **What is the new behavior (if this is a feature change)?**

It removes the `as_is = TRUE` setting in the YAML headers of the vignettes as it reduces compatibility with incoming pkgdown versions.  

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
