### PR TITLE
Remove missed pkgdown as_is = TRUE

### DIFF
--- a/vignettes/interventions.Rmd
+++ b/vignettes/interventions.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >

--- a/vignettes/theoretical_background.Rmd
+++ b/vignettes/theoretical_background.Rmd
@@ -5,8 +5,6 @@ output:
   bookdown::html_vignette2:
     fig_caption: yes
     code_folding: show
-pkgdown:
-  as_is: true
 bibliography: references.json
 link-citations: true
 vignette: >


### PR DESCRIPTION
In a previous PR #269, the setting `pkgdown: as_is` was removed from vignettes but this was incomplete. This PR follows up on the linked PR and removes others that were missed. 
