### PR TITLE
Use "unreleased" development mode for pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,7 +4,7 @@ template:
   bslib:
     font_weight_base : 300
 development:
-  mode: auto
+  mode: unreleased
 
 reference:
   - title: Simulate branching processes


### PR DESCRIPTION
This PR changes the `pkgdown` settings to render the website, showing the latest developments on the package after the most recent release and before the next release. Previously, we were rendering the released version, so all current developments were not showing up on the website.

The website rendering options are currently being discussed here https://github.com/epiverse-trace/blueprints/issues/100.