### PR TITLE
Use `pkgdown` `auto` mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # epichains (development version)
 
+# epichains 0.1.1.9000
+
+## Package
+
+- The package now has websites for the [development version on GitHub](https://epiverse-trace.github.io/epichains/dev/) and [CRAN version](https://epiverse-trace.github.io/epichains/). By @jamesmbaazam in #293 and self-reviewed.
+
 # epichains 0.1.1
 
 This is the first CRAN release of `{epichains}`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -167,6 +167,10 @@ likelihood_eg
 Each of the listed functionalities is demonstrated in detail
 in the ["Getting Started" vignette](https://epiverse-trace.github.io/epichains/articles/epichains.html).
 
+## Package websites
+
+The package has two websites: one for [the stable release version on CRAN](https://epiverse-trace/epichains), and another for [the version in development](https://epiverse-trace/epichains/dev/).
+
 ## Package vignettes
 
 The theory behind the models provided here can be

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Each of the listed functionalities is demonstrated in detail in the
 [“Getting Started”
 vignette](https://epiverse-trace.github.io/epichains/articles/epichains.html).
 
+## Package websites
+
+The package has two websites: one for [the stable release version on
+CRAN](https://epiverse-trace/epichains), and another for [the version in
+development](https://epiverse-trace/epichains/dev/).
+
 ## Package vignettes
 
 The theory behind the models provided here can be found in the [theory

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,7 +4,7 @@ template:
   bslib:
     font_weight_base : 300
 development:
-  mode: unreleased
+  mode: auto
 
 reference:
   - title: Simulate branching processes


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

This PR changes the website mode to `auto` so that users can switch between the development and CRAN websites. A section has also been added to the README to mention the existence of the two websites.