### PR TITLE
Fix wrong website URLs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -169,7 +169,7 @@ in the ["Getting Started" vignette](https://epiverse-trace.github.io/epichains/a
 
 ## Package websites
 
-The package has two websites: one for [the stable release version on CRAN](https://epiverse-trace/epichains), and another for [the version in development](https://epiverse-trace/epichains/dev/).
+The package has two websites: one for [the stable release version on CRAN](https://epiverse-trace.github.io/epichains/), and another for [the version in development](https://epiverse-trace.github.io/epichains/dev/).
 
 ## Package vignettes
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ vignette](https://epiverse-trace.github.io/epichains/articles/epichains.html).
 ## Package websites
 
 The package has two websites: one for [the stable release version on
-CRAN](https://epiverse-trace/epichains), and another for [the version in
-development](https://epiverse-trace/epichains/dev/).
+CRAN](https://epiverse-trace.github.io/epichains/), and another for [the
+version in
+development](https://epiverse-trace.github.io/epichains/dev/).
 
 ## Package vignettes
 


### PR DESCRIPTION
In #290, the README was updated to include a section with the package websites but the URLs were wrong. This PR follows up to fix that issue.