### PR TITLE
Enhance performance of `simulate_chains()`

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -233,7 +233,7 @@ simulate_chains <- function(n_chains,
     # initialise place holder for the number of offspring
     n_offspring <- rep(0L, n_chains)
     # find the number of new offspring for each active simulation
-    n_offspring[chains_active] <- tapply(next_gen, active_chain_ids, sum)
+    n_offspring[chains_active] <- rowsum(next_gen, active_chain_ids)
     # update the size/length statistic
     stat_track <- .update_chain_stat(
       stat_type = statistic,

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -258,13 +258,12 @@ simulate_chains <- function(n_chains,
       susc_pop <- susc_pop - sum(n_offspring)
 
       # store new simulation results
-      sim_df[[generation]] <-
-        data.frame(
-          chain = active_chain_ids,
-          infectee = sim_offspring_ids,
-          infector = infector_ids,
-          generation = generation
-        )
+      sim_df[[generation]] <- list2DF(list(
+        chain = active_chain_ids,
+        infectee = sim_offspring_ids,
+        infector = infector_ids,
+        generation = rep(generation, length(active_chain_ids))
+      ))
 
       # if a generation time model/function was specified, use it
       # to generate generation times for the cases


### PR DESCRIPTION
Per #329. Draft for information really. This has a couple of tweaks to improve performance. I was unsure on tests so cached the following locally and compared it between Head and the final commit and all seemed OK.
```R
set.seed(1)
res <-  epichains::simulate_chains(
    n_chains = 1000,
    statistic = "size",
    offspring_dist = stats::rpois,
    lambda = 0.9
)
```
I used the following for benchmarking:

```R
microbenchmark::microbenchmark(
  a=for (i in 1:10) {
    epichains::simulate_chains(
      n_chains = 1000,
      statistic = "size",
      offspring_dist = stats::rpois,
      lambda = 0.9
    )
  },
  setup = quote(set.seed(1))
)

# Head
# Unit: milliseconds
#  expr      min       lq    mean   median      uq      max neval
#     a 157.7172 169.9834 179.068 175.9932 183.733 235.7778   100

# d6c70fe - refactor: use list2DF in hot loop
# Unit: milliseconds
#  expr      min       lq     mean   median       uq      max neval
#     a 101.7172 108.3603 113.7747 111.3616 115.3183 170.9983   100
#    

# fde39d9 - refactor: use rowsum for tapply-sum
# Unit: milliseconds
#  expr      min       lq     mean   median      uq      max neval
#     a 87.10592 91.66845 95.96247 93.51599 98.0845 153.3309   100
```