### PR TITLE
Ignore CLAUDE-related files in package build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,6 @@
 ^CITATION\.cff$
 ^_pkgdown\.yml$
 ^CRAN-SUBMISSION$
+^CLAUDE\.md$
+^CLAUDE\.local\.md$
+^\.claude$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - Design decisions taken during development of the package, along with
   their reasoning and possible pros and cons, are documented in the
-  [design principles vignette](vignettes/design-principles.Rmd)
+  [design principles vignette](https://github.com/epiverse-trace/epichains/blob/main/vignettes/design-principles.Rmd)
 - Consult this vignette before making changes that affect the package's
   architecture, class structures, or overall design
 - Update this vignette when a change introduces or alters a design

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Checking functions previously named `check_*()` have been renamed to `assert_*()` to align with naming conventions used in the `{checkmate}` package.
 - The `simulate_*()` functions now ensure integer operations are safely maintained in computations to ensure memory and computational efficiency.
 - Added a CLAUDE.md file to provide workflow instructions and guardrails to AI agents (#347). 
+- AI assistant files (`CLAUDE.md`, `CLAUDE.local.md`, and `.claude/`) are now excluded from the package build (#352).
 
 # epichains 0.1.1
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -43,6 +43,7 @@ linelists
 ln
 mathbf
 mathrm
+md
 nCoV
 nosoi
 outbreaker


### PR DESCRIPTION
## Description

The `pkgdown` workflow's link check (`untitaker/hyperlink`) fails on any PR that triggers it, with:

```
docs/dev/CLAUDE.html
  error: bad link /dev/vignettes/design-principles.Rmd
```

`pkgdown` renders every top-level `.md` file into the site, so `CLAUDE.md` becomes `docs/dev/CLAUDE.html`. Its relative link to `vignettes/design-principles.Rmd` resolves against the built site, where no such path exists. `pkgdown` only rewrites links to `.md` files, not to `.Rmd` vignettes, so the relative link cannot work there.

This was not caught when `CLAUDE.md` was added because the `pkgdown` workflow's path filters do not include it, so no run happened on `main`. It surfaces on unrelated PRs such as #351.

## Changes

- `CLAUDE.md` now links to the design principles vignette by absolute URL, which resolves both on GitHub and on the rendered site. External links are not checked by `hyperlink`, so the check passes.
- AI assistant files (`CLAUDE.md`, `CLAUDE.local.md`, `.claude/`) are excluded from the package build via `.Rbuildignore`. Note this does not affect `pkgdown`, which ignores `.Rbuildignore` when rendering top-level markdown — the link fix is what resolves the failing check.

Because `.Rbuildignore` is in the `pkgdown` workflow's path filters, this PR triggers the check itself and verifies the fix.

## Checklist

- [x] Any new or changed functionality has documentation
- [x] Added a NEWS.md item
- [x] All checks pass