### PR TITLE
Fix integer check for offspring distribution output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@
 - The README now has badges for CRAN monthly and total downloads as well as the package's Zenodo DOI.
 - The theory vignette now has a references section. By @Degoot-AM in #316.
 
+## Bug fixes
+
+- A bug was fixed where the check that an offspring distribution returns
+  integers passed for output containing a mix of integer and non-integer
+  values (#353).
+
 ## Internal changes
 
 - Checking functions previously named `check_*()` have been renamed to `assert_*()` to align with naming conventions used in the `{checkmate}` package.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -77,7 +77,7 @@
   # check that offspring distribution returns integers
   stopifnot(
     "Offspring distribution must return integers" =
-      !all(possible_new_offspring %% 1 > 0)
+      possible_new_offspring %% 1 == 0
   )
 
   possible_new_offspring

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -105,7 +105,8 @@ test_that(".init_susc_pop works correctly", {
   )
 })
 
-test_that(".sample_possible_offspring errors for mixed integer output", {
+test_that(".sample_possible_offspring validates integer output", {
+  # Mixed integer / non-integer output should error
   expect_error(
     .sample_possible_offspring(
       offspring_func = function(n) c(1, rep(1.5, n - 1)),
@@ -114,6 +115,28 @@ test_that(".sample_possible_offspring errors for mixed integer output", {
       chains = 1
     ),
     "Offspring distribution must return integers"
+  )
+
+  # NA values should error
+  expect_error(
+    .sample_possible_offspring(
+      offspring_func = function(n) c(1, NA_real_),
+      offspring_func_pars = list(),
+      n_offspring = 2,
+      chains = 1
+    ),
+    "Offspring distribution must return integers"
+  )
+
+  # Empty output should be allowed (n = 0)
+  expect_length(
+    .sample_possible_offspring(
+      offspring_func = function(n) numeric(0),
+      offspring_func_pars = list(),
+      n_offspring = 0,
+      chains = 1
+    ),
+    0
   )
 })
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -105,6 +105,18 @@ test_that(".init_susc_pop works correctly", {
   )
 })
 
+test_that(".sample_possible_offspring errors for mixed integer output", {
+  expect_error(
+    .sample_possible_offspring(
+      offspring_func = function(n) c(1, rep(1.5, n - 1)),
+      offspring_func_pars = list(),
+      n_offspring = 10,
+      chains = 1
+    ),
+    "Offspring distribution must return integers"
+  )
+})
+
 test_that(".init_susc_pop works correctly", {
   next_gen <- c(1, 2, 5)
   expect_length(


### PR DESCRIPTION
## Description

Retargeted onto `fix-linting-issues` (#348) so the fix ships together with the lint fixes and CI passes.

The integer validation in `.sample_possible_offspring()` was logically inverted and let invalid output through.

```r
stopifnot(
  "Offspring distribution must return integers" =
    !all(possible_new_offspring %% 1 > 0)
)
```

`!all(x %% 1 > 0)` only fails when *every* value is non-integer. A mix of integer and non-integer values passes validation:

| input | before | after |
| --- | --- | --- |
| `c(1, 2, 3)` | pass | pass |
| `c(1.5, 2.5)` | error | error |
| `c(1, 1.5)` | **pass** | error |
| `c(1, NA)` | **pass** | error |
| `numeric(0)` | **error** | pass |

Note the last row: the previous form also errored on an empty vector, since `all(logical(0))` is `TRUE`.

## Change

```r
stopifnot(
  "Offspring distribution must return integers" =
    possible_new_offspring %% 1 == 0
)
```

This states the intent positively — every value is a whole number — which is what the error message already claims. `stopifnot()` applies `all()` internally, so the wrapper is unnecessary; this also satisfies `lintr`'s `stopifnot_all_linter`. The custom error message is preserved unchanged.

## Verification

- Regression tests cover mixed integer/non-integer output, `NA` values, and empty output. The mixed-output test was confirmed to fail against the previous implementation and pass with the fix.
- Full test suite passes.
- `R/helpers.R` and `tests/testthat/test-helpers.R` are both lint-clean on this base.

This addresses the `R/helpers.R` review comment on #348.