### PR TITLE
Regenerate package-level documentation and bump roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2.9000
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,8 +13,12 @@ export(rborel)
 export(rgborel)
 export(simulate_chain_stats)
 export(simulate_chains)
-importFrom(stats,aggregate)
-importFrom(stats,rgamma)
-importFrom(stats,rpois)
-importFrom(utils,head)
-importFrom(utils,tail)
+importFrom(stats,
+  aggregate,
+  rgamma,
+  rpois
+)
+importFrom(utils,
+  head,
+  tail
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@
 - Added a CLAUDE.md file to provide workflow instructions and guardrails to AI agents (#347). 
 - AI assistant files (`CLAUDE.md`, `CLAUDE.local.md`, and `.claude/`) are now excluded from the package build (#352).
 - Resolved outstanding linting issues across the package source and vignettes to keep the codebase compliant with the project's `{lintr}` configuration (#348).
-- Documentation is now generated with roxygen2 8.1.0 (#355).
+- Documentation is now generated with `{roxygen2}` 8.1.0 (#355).
 
 # epichains 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 - The README now has badges for CRAN monthly and total downloads as well as the package's Zenodo DOI.
 - The theory vignette now has a references section. By @Degoot-AM in #316.
 - Added alternative text to images in the README and the `projecting_incidence` vignette to improve screen-reader accessibility (#338).
+- The package-level documentation (`?epichains`) now lists all authors and
+  contributors recorded in `DESCRIPTION` and displays the package logo. Two
+  people were previously missing from the rendered author list (#355).
 
 ## Bug fixes
 
@@ -28,6 +31,7 @@
 - Added a CLAUDE.md file to provide workflow instructions and guardrails to AI agents (#347). 
 - AI assistant files (`CLAUDE.md`, `CLAUDE.local.md`, and `.claude/`) are now excluded from the package build (#352).
 - Resolved outstanding linting issues across the package source and vignettes to keep the codebase compliant with the project's `{lintr}` configuration (#348).
+- Documentation is now generated with roxygen2 8.1.0 (#355).
 
 # epichains 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 - Added alternative text to images in the README and the `projecting_incidence` vignette to improve screen-reader accessibility (#338).
 - The package-level documentation (`?epichains`) now lists all authors and
   contributors recorded in `DESCRIPTION` and displays the package logo. Two
-  people were previously missing from the rendered author list (#355).
+  people were previously missing from the rendered lists (#355).
 
 ## Bug fixes
 

--- a/man/epichains-package.Rd
+++ b/man/epichains-package.Rd
@@ -6,7 +6,7 @@
 \alias{epichains-package}
 \title{epichains: Simulating and Analysing Transmission Chain Statistics Using Branching Process Models}
 \description{
-\if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
+\if{html}{\figure{logo.svg}{options: style='float: right' alt='epichains logo' width='120'}}
 
 Provides methods to simulate and analyse the size and length of branching processes with an arbitrary offspring distribution. These can be used, for example, to analyse the distribution of chain sizes or length of infectious disease outbreaks, as discussed in Farrington et al. (2003) \doi{10.1093/biostatistics/4.2.279}.
 }

--- a/man/epichains-package.Rd
+++ b/man/epichains-package.Rd
@@ -6,6 +6,8 @@
 \alias{epichains-package}
 \title{epichains: Simulating and Analysing Transmission Chain Statistics Using Branching Process Models}
 \description{
+\if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
+
 Provides methods to simulate and analyse the size and length of branching processes with an arbitrary offspring distribution. These can be used, for example, to analyse the distribution of chain sizes or length of infectious disease outbreaks, as discussed in Farrington et al. (2003) \doi{10.1093/biostatistics/4.2.279}.
 }
 \seealso{
@@ -22,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item James M. Azam \email{james.azam@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5782-7330}{ORCID}) [copyright holder]
   \item Sebastian Funk \email{sebastian.funk@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-2842-3406}{ORCID}) [copyright holder]
   \item Flavio Finger \email{flavio.finger@epicentre.msf.org} (\href{https://orcid.org/0000-0002-8613-5170}{ORCID})
 }
@@ -33,6 +36,7 @@ Other contributors:
   \item Karim Mané \email{karim.mane@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-9892-2999}{ORCID}) [reviewer]
   \item Pratik Gupte \email{pratik.gupte@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5294-7819}{ORCID}) [reviewer]
   \item Joshua W. Lambert \email{joshua.lambert@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5218-3046}{ORCID}) [reviewer]
+  \item Chris Hartgerink \email{chris@data.org} (\href{https://orcid.org/0000-0003-1050-6809}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
## Description

`man/epichains-package.Rd` was stale relative to `DESCRIPTION`: two people listed in `Authors@R` were missing from the rendered package documentation, and the hex logo was not shown. This was noticed while regenerating `likelihood.Rd` in #340, where it was out of scope.

This PR regenerates the package-level documentation and records the current roxygen2 version.

## Changes

**`man/epichains-package.Rd`** — regenerated, which restores three things already present in `DESCRIPTION` but absent from the committed Rd:

- **James M. Azam** (`aut`, `cre`, `cph`) was missing from the Authors list.
- **Chris Hartgerink** (`ctb`) was missing from the Other contributors list.
- The hex logo (`man/figures/logo.svg`) is now shown in the HTML rendering.

The first two mean `?epichains` has been under-crediting two people.

**`DESCRIPTION`** — roxygen2 bumped from `7.3.2.9000` to `8.1.0`, the current CRAN release. roxygen2 8.x records this as `Config/roxygen2/version:` rather than `RoxygenNote:`, so that field is renamed.

**`NAMESPACE`** — roxygen2 8.1.0 emits grouped, multi-line `importFrom()` directives rather than one call per import:

```r
importFrom(stats,
  aggregate,
  rgamma,
  rpois
)
```

This is purely a formatting change. Verified equivalent by installing the package and inspecting `getNamespaceImports()`: `stats` still provides `aggregate`, `rgamma`, `rpois` and `utils` still provides `head`, `tail`, with the same 6 exports as before.

## Verification

- `R CMD check --as-cran`: **0 errors, 0 warnings**. The single NOTE is the standard `Version contains large components (0.1.1.9000)` dev-version note, which CI suppresses via `_R_CHECK_CRAN_INCOMING_`.
- `tools::codoc(dir = ".")` reports no mismatches.
- Full test suite passes.
- `lintr::lint_package()` reports 0 lints.
- `spelling::spell_check_package()` reports no errors.
- No workflow in this repo regenerates documentation, so the roxygen2 version bump does not affect CI.

## Note for contributors

After this merges, contributors regenerating documentation will need roxygen2 >= 8.0.0. An older roxygen2 does not recognise `Config/roxygen2/version:` and will re-add a `RoxygenNote:` field alongside it.

## Checklist

- [x] Added a NEWS.md item
- [x] Documentation regenerated
- [x] All checks pass locally