### PR TITLE
Regenerate package-level documentation

### DIFF
--- a/man/epichains-package.Rd
+++ b/man/epichains-package.Rd
@@ -6,7 +6,7 @@
 \alias{epichains-package}
 \title{epichains: Simulating and Analysing Transmission Chain Statistics Using Branching Process Models}
 \description{
-\if{html}{\figure{logo.svg}{options: style='float: right' alt='epichains logo' width='120'}}
+\if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
 
 Provides methods to simulate and analyse the size and length of branching processes with an arbitrary offspring distribution. These can be used, for example, to analyse the distribution of chain sizes or length of infectious disease outbreaks, as discussed in Farrington et al. (2003) \doi{10.1093/biostatistics/4.2.279}.
 }


### PR DESCRIPTION
## Problem

`man/epichains-package.Rd` is generated by roxygen2, but its logo alternative text had been changed by hand to `alt='epichains logo'` in "Make Alt text more informative".

roxygen2 hard-codes that value, with no option to configure it:

```r
# roxygen2:::object_defaults.package
fig <- paste_c(c("\\if{html}{\\figure{", logo_file, "}"),
               "{options: style='float: right' alt='logo' width='120'}}\n\n")
```

So the hand-edit was reverted by every `roxygen2::roxygenise()` run. This was not hypothetical — it reappeared on three separate branches while preparing #339, #340 and #355 for merge, and had to be discarded by hand each time. Left as it was, it would eventually have been committed by accident, producing a confusing diff in an unrelated PR.

## Change

`man/epichains-package.Rd` is regenerated, restoring `alt='logo'`.

This is the value roxygen2 and `usethis` produce automatically, so the generated file is now consistent with its source and stays that way. No source file changes: `R/epichains-package.R` is untouched.

```diff
-\if{html}{\figure{logo.svg}{options: style='float: right' alt='epichains logo' width='120'}}
+\if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
```

No NEWS item: this only realigns a generated file with its source and has no user-facing effect.

## Verification

- Running `roxygenise()` twice produces no further change, so regeneration is now stable.
- `lintr::lint_package()` reports 0 lints.
- Full test suite passes.
- `tools::codoc(dir = ".")` reports no mismatches.
- `spelling::spell_check_package()` reports no errors.

## Checklist

- [x] Documentation regenerated
- [x] All checks pass locally